### PR TITLE
Attribute namespaces

### DIFF
--- a/reflex-dom.cabal
+++ b/reflex-dom.cabal
@@ -23,7 +23,7 @@ library
     reflex == 0.3.*,
     dependent-sum == 0.2.*,
     dependent-map == 0.1.*,
-    semigroups == 0.16.*,
+    semigroups >= 0.16 && < 0.19,
     mtl >= 2.1 && < 2.3,
     containers == 0.5.*,
     these >= 0.4,

--- a/src/Reflex/Dom/Widget/Basic.hs
+++ b/src/Reflex/Dom/Widget/Basic.hs
@@ -74,11 +74,6 @@ instance MonadWidget t m => Attributes m (Dynamic t AttributeMap) where
       forM_ (Set.toList $ oldAttrs `Set.difference` Map.keysSet newAttrs) $ elementRemoveAttribute e
       imapM_ (elementSetAttribute e) newAttrs --TODO: avoid re-setting unchanged attributes; possibly do the compare using Align in haskell
 
-splitNSAttr :: String -> (Maybe String, String)
-splitNSAttr attr = case List.elemIndex ':' attr of
-  Nothing -> (Nothing, attr)
-  Just n  -> let (a,b) = List.splitAt n attr in (Just a, b)
-
 instance MonadIO m => Attributes m AttributeNSMap where
   addAttributes curAttrs e = liftIO $ imapM_  (addAttrNS e) curAttrs
 


### PR DESCRIPTION
Allow creation of elements with namespaced attributes. It's not enough to give an attribute prefix in the same string with the attribute name:
```haskell
elAttr "use" ("xlink:href" =: "#MyPath") $ return ()
``` 
Will produce the html, which looks exactly right, but won't work as expected, because the javascript code producing the attributes won't actually put them into the `http://www.w3c.org/1999/xlink` namespace URI:
```html
<use xlink:href="#MyPath">
```

What we can do with the added function `elNSDynAttrNS'` is to pass an attribute list with explicit namespaces. To get the desired effect:
```haskell
elNSDynAttrNS' "svg" "use" 
  (constDyn $ ("http://www.w3c.org/1999/xlink", "xlink:href") =: "#MyPath") $ return ()
```

This produces what looks like the same html nodes, but the attribute will have been created in the proper namespace. Here is a full [worked example](https://gist.github.com/imalsogreg/66d441db764ff67f945b) of dynamic [text-on-path](http://web.mit.edu/greghale/Public/textonpath/), modeled after the [example on MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/textPath). *Click the check-boxes and start typing some text*.  The checkboxes toggle namespaced and not-namespaced attributes respectively, so that we can watch them in the Developer Tools pane and make sure they're being added and deleted as expected.