### PR TITLE
Send while WebSocket is in Pending state.

### DIFF
--- a/src-ghcjs/Reflex/Dom/WebSocket/Foreign.hs
+++ b/src-ghcjs/Reflex/Dom/WebSocket/Foreign.hs
@@ -39,6 +39,7 @@ webSocketSend (JSWebSocket ws) bs = do
   ab <- ArrayBuffer <$> if BS.length bs == 0 --TODO: remove this logic when https://github.com/ghcjs/ghcjs-base/issues/49 is fixed
                         then jsval . getArrayBuffer <$> create 0
                         else return $ js_dataView off len $ jsval $ getArrayBuffer b
-  GD.send ws $ Just ab
+  rs <- GD.getReadyState ws
+  when (rs == GD.OPEN) $ GD.send ws $ Just ab
 
 foreign import javascript safe "new DataView($3,$1,$2)" js_dataView :: Int -> Int -> JSVal -> JSVal


### PR DESCRIPTION
It is possible for reflex-dom to send a message into a socket that is still in a PENDING ReadyState, that is when it is building up a websocket connection.  When it does so, that causes a javascript error about trying to use an object that is not ready, breaking the whole page.

I'm not sure if this is technically a ghcjs-dom bug or a reflex-dom bug but it is certainly fixable here.