### PR TITLE
Prefer getClientX over getX

### DIFF
--- a/src/Reflex/Dom/Widget/Basic.hs
+++ b/src/Reflex/Dom/Widget/Basic.hs
@@ -623,7 +623,7 @@ getKeyEvent = do
 getMouseEventCoords :: EventM e MouseEvent (Int, Int)
 getMouseEventCoords = do
   e <- event
-  bisequence (getX e, getY e)
+  bisequence (getClientX e, getClientY e)
 
 defaultDomEventHandler :: IsElement e => e -> EventName en -> EventM e (EventType en) (Maybe (EventResult en))
 defaultDomEventHandler e evt = liftM (Just . EventResult) $ case evt of


### PR DESCRIPTION
This change uses `getClientX` in place of `getX` in the implementation of `getMouseEventCoords`.

Some research:

`getX` calls a javascript MouseEvent method that has an experimental flag in the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/x) and is not supported under Firefox.

An [example](http://web.mit.edu/greghale/Public/mousenew2/) compiled against `getClientX`/`getClientY`  works under Chome & Firefox. The [same example](http://web.mit.edu/greghale/Public/mouseold/) compiled with the version of `getMouseEventCoords` using `getX`/`getY` works in Chrome but not in Firefox.

## Side-proposal

It's more common for me to want Mouseevent coordinates relative to the element catching the event, rather than relative to the corner of the client. There are `uiLayerX` and `mouseOffsetX`, which cover both the Chrome and Firefox case and report position relative to the element catching the event. Tested in [this](https://github.com/reflex-frp/reflex-dom/compare/develop...imalsogreg:coords) branch, example of the results [here](http://web.mit.edu/greghale/Public/mousenew/) 

It would be a breaking change to switch to reporting element-centered coordinates - do you have an idea of how many people are using mouse event coordinates? If the behavior of Mouseevents here can change, should we change it? Or is there another way to conveniently provide element-relative coordinates?