### PR TITLE
Add local fs warning

### DIFF
--- a/src-ghc/Reflex/Dom/Xhr/Foreign.hs
+++ b/src-ghc/Reflex/Dom/Xhr/Foreign.hs
@@ -214,3 +214,7 @@ xmlHttpRequestSetWithCredentials xhr b = do
   _ <- jsevaluatescript c script o nullPtr 1 nullPtr
   return ()
 
+-- Checking 'window.location' is skipped for webkitgtk apps because
+-- they are always served from the local filesystem
+localFilesystemCheck :: WebView -> IO ()
+localFilesystemCheck _ = return ()

--- a/src-ghcjs/Reflex/Dom/Internal/Foreign.hs
+++ b/src-ghcjs/Reflex/Dom/Internal/Foreign.hs
@@ -41,3 +41,8 @@ bsToArrayBuffer _ bs = BS.useAsCString bs $ \cStr -> do
 
 bsFromArrayBuffer :: a -> JSVal -> IO ByteString
 bsFromArrayBuffer _ ab = liftM (JS.toByteString 0 Nothing . JS.createFromArrayBuffer) $ JS.unsafeFreeze $ JS.pFromJSVal ab
+
+consoleWarn :: ToJSString s => s -> IO ()
+consoleWarn = js_consoleWarn . toJSString
+
+foreign import javascript unsafe "console.warn($1)" js_consoleWarn :: JSString -> IO ()

--- a/src-ghcjs/Reflex/Dom/Xhr/Foreign.hs
+++ b/src-ghcjs/Reflex/Dom/Xhr/Foreign.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface, JavaScriptFFI, OverloadedStrings #-}
+{-# LANGUAGE ForeignFunctionInterface, JavaScriptFFI, OverloadedStrings, ScopedTypeVariables #-}
 
 module Reflex.Dom.Xhr.Foreign (
     XMLHttpRequest
@@ -7,6 +7,7 @@ module Reflex.Dom.Xhr.Foreign (
 ) where
 
 import Prelude hiding (error)
+import Control.Monad (when)
 import Data.Text (Text)
 import GHCJS.DOM.Types hiding (Text)
 import GHCJS.DOM
@@ -149,3 +150,9 @@ xmlHttpRequestGetResponse xhr = do
          Just ptr -> fmap (Just . XhrResponseBody_ArrayBuffer) $ bsFromArrayBuffer ptr ptr
        _ -> return Nothing
 
+localFilesystemCheck :: WebView -> IO ()
+localFilesystemCheck wv = do
+  p :: String <- getLocationProtocol wv
+  when ("file" == take 4 p) $ consoleWarn
+    ("Warning: XHR requests made from a page served directly from the local filesystem "
+    ++ "(file:///) may not work." :: String)

--- a/src/Reflex/Dom/Xhr.hs
+++ b/src/Reflex/Dom/Xhr.hs
@@ -122,7 +122,7 @@ newXMLHttpRequestWithError
     -- ^ The XHR request, which could for example be aborted.
 newXMLHttpRequestWithError req cb = do
   wv <- askWebView
-  localFilesystemCheck wv
+  liftIO $ localFilesystemCheck wv
   postGui <- askPostGui
   xhr <- liftIO $ xmlHttpRequestNew wv
   void $ liftIO $ forkIO $ flip catch (postGui . cb . Left) $ void $ do
@@ -233,11 +233,3 @@ decodeText = decode . BL.fromStrict . encodeUtf8
 -- | Convenience function to decode JSON-encoded responses.
 decodeXhrResponse :: FromJSON a => XhrResponse -> Maybe a
 decodeXhrResponse = join . fmap decodeText . _xhrResponse_responseText
-
-
-localFilesystemCheck :: MonadIO m => WebView -> m ()
-localFilesystemCheck wv = liftIO $ do
-  p <- getLocationProtocol wv
-  when ("file" == take 4 p) $ print $
-    "Warning: XHR requests made from a page served directly from the local filesystem "
-    ++ "(file:///) may not work."


### PR DESCRIPTION
When building an XHRHttpRequest, check the protocol part of the window's location. If the window is served from 'file:///', print a warning to the user.

This is meant to help debug in the case of accidentally trying to make a CORS request from a page served from 'file:///'.
