### PR TITLE
Enabled support for aeson-0.11

### DIFF
--- a/reflex-dom.cabal
+++ b/reflex-dom.cabal
@@ -39,7 +39,7 @@ library
     text == 1.2.*,
     bytestring == 0.10.*,
     data-default == 0.5.*,
-    aeson >= 0.8 && < 0.11,
+    aeson >= 0.8 && < 0.12,
     time == 1.4.* || == 1.5.*,
     exception-transformers == 0.4.*,
     directory == 1.2.*,


### PR DESCRIPTION
My local tests show no problem with aeson-0.11 and unfortunately I haven't found proper tests to be 100% sure