### PR TITLE
Add IsXhrPayload instance for String under GHC

### DIFF
--- a/src-ghc/Reflex/Dom/Xhr/Foreign.hs
+++ b/src-ghc/Reflex/Dom/Xhr/Foreign.hs
@@ -40,6 +40,9 @@ instance IsXhrPayload () where
 instance IsXhrPayload Text where
   xmlHttpRequestSend xhr = xmlHttpRequestSendPayload xhr . Just
 
+instance IsXhrPayload String where
+  xmlHttpRequestSend xhr = xmlHttpRequestSendPayload xhr . Just . T.pack
+
 instance IsXhrPayload File where
   xmlHttpRequestSend = error "xmlHttpRequestSend{File}: not implemented"
 


### PR DESCRIPTION
Together with https://github.com/reflex-frp/reflex-dom/pull/83 both ghcjs and ghc will have `IsXhrPayload` instances for both `String` and `Text`