### PR TITLE
Allow sending websocket messages in binary or text

### DIFF
--- a/src-ghc/Reflex/Dom/WebSocket/Foreign.hs
+++ b/src-ghc/Reflex/Dom/WebSocket/Foreign.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -32,11 +33,39 @@ import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSStringRef
 import Graphics.UI.Gtk.WebKit.JavaScriptCore.JSValueRef
 import Graphics.UI.Gtk.WebKit.WebView
 
+import Foreign.JavaScript.TH
 import Reflex.Dom.Internal.Foreign
 
 data JSWebSocket = JSWebSocket { wsValue :: JSValueRef
                                , wsContext :: JSContextRef
                                }
+
+importJS Unsafe "this[0]['send'](this[1])" "_sendWSTextData" [t| forall x m. MonadJS x m => JSRef x -> String -> m () |]
+
+sendWSTextData :: JSWebSocket -> String -> IO ()
+sendWSTextData (JSWebSocket ws c) str = runWithJSContext (_sendWSTextData (JSRef_JavaScriptCore ws) str) c
+
+class IsWebSocketMessage a where
+  webSocketSend :: JSWebSocket -> a -> IO ()
+
+-- Use binary websocket communication for ByteString
+instance IsWebSocketMessage ByteString where
+  webSocketSend (JSWebSocket ws c) bs = do
+    elems <- forM (BS.unpack bs) $ \x -> jsvaluemakenumber c $ fromIntegral x
+    let numElems = length elems
+    bs' <- bracket (mallocArray numElems) free $ \elemsArr -> do
+      pokeArray elemsArr elems
+      a <- jsobjectmakearray c (fromIntegral numElems) elemsArr nullPtr
+      newUint8Array <- jsstringcreatewithutf8cstring "new Uint8Array(this)"
+      jsevaluatescript c newUint8Array a nullPtr 1 nullPtr
+    send <- jsstringcreatewithutf8cstring ""
+    sendArgs <- toJSObject c [ws, bs']
+    _ <- jsevaluatescript c send sendArgs nullPtr 1 nullPtr
+    return ()
+
+-- Use plaintext websocket communication for Text
+instance IsWebSocketMessage Text where
+  webSocketSend jws t = sendWSTextData jws (T.unpack t)
 
 newWebSocket :: WebView -> Text -> (ByteString -> IO ()) -> IO () -> IO () -> IO JSWebSocket
 newWebSocket wv url onMessage onOpen onClose = withWebViewContext wv $ \c -> do
@@ -66,18 +95,3 @@ newWebSocket wv url onMessage onOpen onClose = withWebViewContext wv $ \c -> do
   addCbs <- jsstringcreatewithutf8cstring "this[0]['onmessage'] = this[1]; this[0]['onopen'] = this[2]; this[0]['onclose'] = this[3];"
   _ <- jsevaluatescript c addCbs o nullPtr 1 nullPtr
   return $ JSWebSocket ws c
-
-webSocketSend :: JSWebSocket -> ByteString -> IO ()
-webSocketSend (JSWebSocket ws c) bs = do
-  elems <- forM (BS.unpack bs) $ \x -> jsvaluemakenumber c $ fromIntegral x
-  let numElems = length elems
-  bs' <- bracket (mallocArray numElems) free $ \elemsArr -> do
-    pokeArray elemsArr elems
-    a <- jsobjectmakearray c (fromIntegral numElems) elemsArr nullPtr
-    newUint8Array <- jsstringcreatewithutf8cstring "new Uint8Array(this)"
-    jsevaluatescript c newUint8Array a nullPtr 1 nullPtr
-  send <- jsstringcreatewithutf8cstring "this[0]['send'](String['fromCharCode']['apply'](null, this[1]))"
-  sendArgs <- toJSObject c [ws, bs']
-  _ <- jsevaluatescript c send sendArgs nullPtr 1 nullPtr
-  return ()
-

--- a/src/Reflex/Dom/WebSocket.hs
+++ b/src/Reflex/Dom/WebSocket.hs
@@ -42,11 +42,11 @@ import Data.IORef
 import Data.Maybe (isJust)
 import Data.Text
 
-data WebSocketConfig t
-   = WebSocketConfig { _webSocketConfig_send :: Event t [ByteString]
+data WebSocketConfig t a
+   = WebSocketConfig { _webSocketConfig_send :: Event t [a]
                      }
 
-instance Reflex t => Default (WebSocketConfig t) where
+instance Reflex t => Default (WebSocketConfig t a) where
   def = WebSocketConfig never
 
 data WebSocket t
@@ -54,7 +54,13 @@ data WebSocket t
                , _webSocket_open :: Event t ()
                }
 
-webSocket :: (MonadIO m, MonadIO (Performable m), HasWebView m, PerformEvent t m, TriggerEvent t m, PostBuild t m) => Text -> WebSocketConfig t -> m (WebSocket t)
+-- This can be used to send either binary or text messages for the same websocket connection
+instance (IsWebSocketMessage a, IsWebSocketMessage b) => IsWebSocketMessage (Either a b) where
+  webSocketSend jws (Left a) = webSocketSend jws a
+  webSocketSend jws (Right a) = webSocketSend jws a
+
+
+webSocket :: (MonadIO m, MonadIO (Performable m), HasWebView m, PerformEvent t m, TriggerEvent t m, PostBuild t m, IsWebSocketMessage a) => Text -> WebSocketConfig t a -> m (WebSocket t)
 webSocket url config = do
   wv <- fmap unWebViewSingleton askWebView
   (eRecv, onMessage) <- newTriggerEvent


### PR DESCRIPTION
This PR makes the websocket message type polymorphic so that messages can be sent in either text of binary form. It's also possible to use 'Either Text ByteString' to allow switching between text and binary formats for the same websocket.