### PR TITLE
Export ElConfig

### DIFF
--- a/src/Reflex/Dom/Old.hs
+++ b/src/Reflex/Dom/Old.hs
@@ -11,6 +11,7 @@
 module Reflex.Dom.Old
        ( MonadWidget
        , El
+       , ElConfig (..)
        , _el_clicked
        , _el_element
        , _el_events


### PR DESCRIPTION
Without it functions like `elWith'` are just unusable