### PR TITLE
Build with stack lts 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ hsenv.log
 \#*#
 .#*
 *_stub.h
+.cabal-sandbox/
+cabal.sandbox.config
+.stack-work

--- a/reflex-dom.cabal
+++ b/reflex-dom.cabal
@@ -42,7 +42,7 @@ library
     blaze-builder,
     bytestring == 0.10.*,
     data-default >= 0.5 && < 0.8,
-    aeson >= 0.8 && < 0.12,
+    aeson >= 0.8 && < 1.1,
     time >= 1.4 && < 1.7,
     exception-transformers == 0.4.*,
     directory == 1.2.*,


### PR DESCRIPTION
I'm using `stack` to build my `ghcjs` project and the `stack.yaml` found [in the docs](https://docs.haskellstack.org/en/stable/ghcjs/) works fine with the latest `reflex` when the upper bound on aeson is relaxed.