### PR TITLE
Improve websocket API

### DIFF
--- a/src-ghc/Reflex/Dom/Internal/Foreign.hs
+++ b/src-ghc/Reflex/Dom/Internal/Foreign.hs
@@ -126,6 +126,18 @@ fromJSStringMaybe c t = do
            peekCString ps
     return $ Just $ T.pack s
 
+fromJSBoolMaybe :: JSContextRef -> JSValueRef -> IO (Maybe Bool)
+fromJSBoolMaybe c t = do
+  isBool <- jsvalueisboolean c t
+  if not isBool then return Nothing else
+    fmap Just $ jsvaluetoboolean c t
+
+fromJSNumMaybe :: JSContextRef -> JSValueRef -> IO (Maybe Double)
+fromJSNumMaybe c t = do
+  isNum <- jsvalueisnumber c t
+  if not isNum then return Nothing else
+    fmap Just $ jsvaluetonumber c t nullPtr
+
 getLocationHost :: WebView -> IO Text
 getLocationHost wv = withWebViewContext wv $ \c -> do
   script <- jsstringcreatewithutf8cstring "location.host"

--- a/src-ghc/Reflex/Dom/WebSocket/Foreign.hs
+++ b/src-ghc/Reflex/Dom/WebSocket/Foreign.hs
@@ -21,6 +21,7 @@ import Control.Exception
 import Control.Monad.State
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding
@@ -67,8 +68,21 @@ instance IsWebSocketMessage ByteString where
 instance IsWebSocketMessage Text where
   webSocketSend jws t = sendWSTextData jws (T.unpack t)
 
-newWebSocket :: WebView -> Text -> (ByteString -> IO ()) -> IO () -> IO () -> IO JSWebSocket
-newWebSocket wv url onMessage onOpen onClose = withWebViewContext wv $ \c -> do
+importJS Unsafe "this[0]['close'](this[1], this[2])" "_closeWS" [t| forall x m. MonadJS x m => JSRef x -> Double -> String -> m () |]
+
+closeWebSocket :: JSWebSocket -> Double -> Text -> IO ()
+closeWebSocket (JSWebSocket ws c) code reason = do
+  runWithJSContext (_closeWS (JSRef_JavaScriptCore ws) code (T.unpack reason)) c
+
+newWebSocket
+  :: WebView
+  -> Text -- url
+  -> (ByteString -> IO ()) -- onmessage
+  -> IO () -- onopen
+  -> IO () -- onerror
+  -> ((Bool, Word, Text) -> IO ()) -- onclose
+  -> IO JSWebSocket
+newWebSocket wv url onMessage onOpen onError onClose = withWebViewContext wv $ \c -> do
   url' <- jsvaluemakestring c =<< jsstringcreatewithutf8cstring (T.unpack url)
   newWSArgs <- toJSObject c [url']
   newWS <- jsstringcreatewithutf8cstring "(function(that) { var ws = new WebSocket(that[0]); ws['binaryType'] = 'arraybuffer'; return ws; })(this)"
@@ -87,11 +101,25 @@ newWebSocket wv url onMessage onOpen onClose = withWebViewContext wv $ \c -> do
     onOpen
     jsvaluemakeundefined c
   onOpenCb <- jsobjectmakefunctionwithcallback c nullPtr onOpen'
-  onClose' <- wrapper $ \_ _ _ _ _ _ -> do
-    onClose
+  onError' <- wrapper $ \_ _ _ _ _ _ -> do
+    onError
+    jsvaluemakeundefined c
+  onErrorCb <- jsobjectmakefunctionwithcallback c nullPtr onError'
+  onClose' <- wrapper $ \_ _ _ _ args _ -> do
+    e <- peekElemOff args 0
+    propWasClean <- jsstringcreatewithutf8cstring "wasClean"
+    propCode <- jsstringcreatewithutf8cstring "code"
+    propReason <- jsstringcreatewithutf8cstring "reason"
+    wasClean <- fmap (fromMaybe False) $ fromJSBoolMaybe c
+      =<< jsobjectgetproperty c e propWasClean nullPtr
+    code <- fmap (fromMaybe 1000) $ fromJSNumMaybe c
+      =<< jsobjectgetproperty c e propCode nullPtr
+    reason <- fmap (fromMaybe mempty) $ fromJSStringMaybe c
+      =<< jsobjectgetproperty c e propReason nullPtr
+    onClose (wasClean, truncate code, reason)
     jsvaluemakeundefined c
   onCloseCb <- jsobjectmakefunctionwithcallback c nullPtr onClose'
-  o <- toJSObject c [ws, onMessageCb, onOpenCb, onCloseCb]
-  addCbs <- jsstringcreatewithutf8cstring "this[0]['onmessage'] = this[1]; this[0]['onopen'] = this[2]; this[0]['onclose'] = this[3];"
+  o <- toJSObject c [ws, onMessageCb, onOpenCb, onErrorCb, onCloseCb]
+  addCbs <- jsstringcreatewithutf8cstring "this[0]['onmessage'] = this[1]; this[0]['onopen'] = this[2]; this[0]['onerror'] = this[3]; this[0]['onclose'] = this[4];"
   _ <- jsevaluatescript c addCbs o nullPtr 1 nullPtr
   return $ JSWebSocket ws c

--- a/src/Reflex/Dom/WebSocket.hs
+++ b/src/Reflex/Dom/WebSocket.hs
@@ -44,14 +44,23 @@ import Data.Text
 
 data WebSocketConfig t a
    = WebSocketConfig { _webSocketConfig_send :: Event t [a]
+                     , _webSocketConfig_close :: Event t (Word, Text)
+                     , _webSocketConfig_reconnect :: Bool
                      }
 
 instance Reflex t => Default (WebSocketConfig t a) where
-  def = WebSocketConfig never
+  def = WebSocketConfig never never True
 
 data WebSocket t
    = WebSocket { _webSocket_recv :: Event t ByteString
                , _webSocket_open :: Event t ()
+               , _webSocket_error :: Event t () -- eror event does not carry any data and is always
+                                                -- followed by termination of the connection
+                                                -- for details see the close event
+               , _webSocket_close :: Event t ( Bool -- wasClean
+                                             , Word -- code
+                                             , Text -- reason
+                                             )
                }
 
 -- This can be used to send either binary or text messages for the same websocket connection
@@ -65,25 +74,34 @@ webSocket url config = do
   wv <- fmap unWebViewSingleton askWebView
   (eRecv, onMessage) <- newTriggerEvent
   currentSocketRef <- liftIO $ newIORef Nothing
-  --TODO: Disconnect if value no longer needed
   (eOpen, triggerEOpen) <- newTriggerEventWithOnComplete
+  (eError, triggerEError) <- newTriggerEvent
+  (eClose, triggerEClose) <- newTriggerEvent
   payloadQueue <- liftIO newTQueueIO
   isOpen       <- liftIO newEmptyTMVarIO
-  let onOpen = triggerEOpen () $ do
-        liftIO $ void $ atomically $ tryPutTMVar isOpen ()
-      --TODO: Is the fork necessary, or do event handlers run in their own threads automatically?
-      onClose = void $ forkIO $ do
-        _ <- liftIO $ atomically $ tryTakeTMVar isOpen
-        liftIO $ writeIORef currentSocketRef Nothing
-        liftIO $ threadDelay 1000000
-        start
+  let onOpen = triggerEOpen () $ liftIO $ void $ atomically $ tryPutTMVar isOpen ()
+      onError = triggerEError ()
+      onClose args = do
+        triggerEClose args
+        --TODO: Is the fork necessary, or do event handlers run in their own threads automatically?
+        void $ forkIO $ do
+          _ <- liftIO $ atomically $ tryTakeTMVar isOpen
+          liftIO $ writeIORef currentSocketRef Nothing
+          when (_webSocketConfig_reconnect config) $ do
+            liftIO $ threadDelay 1000000
+            start
       start = do
-        ws <- liftIO $ newWebSocket wv url onMessage onOpen onClose
+        ws <- liftIO $ newWebSocket wv url onMessage onOpen onError onClose
         liftIO $ writeIORef currentSocketRef $ Just ws
         return ()
   performEvent_ . (liftIO start <$) =<< getPostBuild
   performEvent_ $ ffor (_webSocketConfig_send config) $ \payloads -> forM_ payloads $ \payload ->
     liftIO $ atomically $ writeTQueue payloadQueue payload
+  performEvent_ $ ffor (_webSocketConfig_close config) $ \(code,reason) -> liftIO $ do
+    mws <- readIORef currentSocketRef
+    case mws of
+      Nothing -> return ()
+      Just ws -> closeWebSocket ws (fromIntegral code) reason
 
   _ <- liftIO $ forkIO $ forever $ do
     payload <- atomically $ do
@@ -98,6 +116,6 @@ webSocket url config = do
                          `catch`
                          (\(_ :: SomeException) -> return False))
     unless success $ atomically $ unGetTQueue payloadQueue payload
-  return $ WebSocket eRecv eOpen
+  return $ WebSocket eRecv eOpen eError eClose
 
 makeLensesWith (lensRules & simpleLenses .~ True) ''WebSocketConfig


### PR DESCRIPTION
Extend websocket API with the following things:

* allow websockets to be closed via event
* add option to control reconnect behavior
* expose error and close events

I had no success making chrome pass actual CloseEvent values downstream. Seems to always be False for wasClean and 1006 for code, even though it does echo back correct values on server initiated close. Not sure if this is a bug in the code somewhere that only displays in Chrome or maybe a "security feature". Firefox and GHC do seem to work well.

I think the only app code that should need refactoring is that using `WebSocketConfig` constructor directly instead of `def`.

Any suggestions most welcome.

Also, now that I think of it some more, it may be misleading that trying to close a websocket by default will cause it to reconnect. Not what anyone would normally expect. Hmm... so either add more logic or document the hell out of it... or change the defaults and break exiting code. I'll try to figure out a clean way to do this tomorrow, maybe.