### PR TITLE
Generalization of tickLossyFrom

### DIFF
--- a/src/Reflex/Dom/Time.hs
+++ b/src/Reflex/Dom/Time.hs
@@ -48,13 +48,23 @@ tickLossyFrom
     -- be something like the result of getPostBuild that only fires once.  But
     -- there could be uses for starting multiple timer threads.
     -> m (Event t TickInfo)
-tickLossyFrom dt t0 e = do
-  rec result <- performEventAsync $ callAtNextInterval <$> leftmost [() <$ e, () <$ result]
-  return result
-  where callAtNextInterval _ cb = void $ liftIO $ forkIO $ do
-          tick <- getCurrentTick dt t0
-          Concurrent.delay $ ceiling $ (dt - _tickInfo_alreadyElapsed tick) * 1000000
-          cb tick
+tickLossyFrom dt t0 e = tickLossyFrom' $ (dt, t0) <$ e
+
+-- | Generalization of tickLossyFrom that takes dt and t0 in the event.
+tickLossyFrom'
+    :: (PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), MonadFix m)
+    => Event t (NominalDiffTime, UTCTime)
+    -- ^ Event that starts a tick generation thread.  Usually you want this to
+    -- be something like the result of getPostBuild that only fires once.  But
+    -- there could be uses for starting multiple timer threads.
+    -> m (Event t TickInfo)
+tickLossyFrom' e = do
+  rec result <- performEventAsync $ callAtNextInterval <$> leftmost [e, snd <$> result]
+  return $ fst <$> result
+  where callAtNextInterval pair cb = void $ liftIO $ forkIO $ do
+          tick <- uncurry getCurrentTick pair
+          Concurrent.delay $ ceiling $ (fst pair - _tickInfo_alreadyElapsed tick) * 1000000
+          cb (tick, pair)
 
 clockLossy :: (MonadIO m, PerformEvent t m, TriggerEvent t m, MonadIO (Performable m), PostBuild t m, MonadHold t m, MonadFix m) => NominalDiffTime -> UTCTime -> m (Dynamic t TickInfo)
 clockLossy dt t0 = do


### PR DESCRIPTION
I found the tickLossyFrom' function useful to avoid the widgetHold that would have been necessary with the existing tickLossyFrom.  In my case I only needed for `t0`, but I figured we might as well go the whole way and include `dt` in the event as well.

Name bikeshedding welcome.