### PR TITLE
Touchmove event now returns a list of coordinates

### DIFF
--- a/src/Reflex/Dom/Builder/Class/Events.hs
+++ b/src/Reflex/Dom/Builder/Class/Events.hs
@@ -149,7 +149,7 @@ type family EventResultType (en :: EventTag) :: * where
   EventResultType 'SearchTag = ()
   EventResultType 'SelectstartTag = ()
   EventResultType 'TouchstartTag = ()
-  EventResultType 'TouchmoveTag = ()
+  EventResultType 'TouchmoveTag = [(Int, Int)]
   EventResultType 'TouchendTag = ()
   EventResultType 'TouchcancelTag = ()
   EventResultType 'WheelTag = ()


### PR DESCRIPTION
Previously, the `Touchmove` event returned `()`, now it returns `[(Int, Int)]`.