### PR TITLE
Expose more TouchEvent information

### DIFF
--- a/src/Reflex/Dom/Builder/Class/Events.hs
+++ b/src/Reflex/Dom/Builder/Class/Events.hs
@@ -148,11 +148,33 @@ type family EventResultType (en :: EventTag) :: * where
   EventResultType 'ResetTag = ()
   EventResultType 'SearchTag = ()
   EventResultType 'SelectstartTag = ()
-  EventResultType 'TouchstartTag = [(Int, Int)]
-  EventResultType 'TouchmoveTag = [(Int, Int)]
-  EventResultType 'TouchendTag = [(Int, Int)]
-  EventResultType 'TouchcancelTag = [(Int, Int)]
+  EventResultType 'TouchstartTag = TouchEventResult
+  EventResultType 'TouchmoveTag = TouchEventResult
+  EventResultType 'TouchendTag = TouchEventResult
+  EventResultType 'TouchcancelTag = TouchEventResult
   EventResultType 'WheelTag = ()
+
+data TouchEventResult = TouchEventResult
+  { _touchEventResult_altKey :: Bool
+  , _touchEventResult_changedTouches :: [TouchResult]
+  , _touchEventResult_ctrlKey :: Bool
+  , _touchEventResult_metaKey :: Bool
+  , _touchEventResult_shiftKey :: Bool
+  , _touchEventResult_targetTouches :: [TouchResult]
+  , _touchEventResult_touches :: [TouchResult]
+  }
+  deriving (Show, Read, Eq, Ord)
+
+data TouchResult = TouchResult
+  { _touchResult_identifier :: Word
+  , _touchResult_screenX :: Int
+  , _touchResult_screenY :: Int
+  , _touchResult_clientX :: Int
+  , _touchResult_clientY :: Int
+  , _touchResult_pageX :: Int
+  , _touchResult_pageY :: Int
+  }
+  deriving (Show, Read, Eq, Ord)
 
 deriveGEq ''EventName
 deriveGCompare ''EventName

--- a/src/Reflex/Dom/Builder/Immediate.hs
+++ b/src/Reflex/Dom/Builder/Immediate.hs
@@ -897,7 +897,6 @@ getTouchEvent = do
           fmap catMaybes . forM [0 .. n - 1] $ \ix -> do
             mt <- TouchList.item ts ix
             forM mt $ \t -> do
-              -- TODO: Applicative?
               identifier <- Touch.getIdentifier t
               screenX <- Touch.getScreenX t
               screenY <- Touch.getScreenY t


### PR DESCRIPTION
Note that this, like the TouchEvent work that preceded it, doesn't fix the GHC implementation or put the alternative implementations in the src-ghc and src-ghcjs trees.

Once the jsaddle branch is merged, the ghc implementation should be straightforward and I'll move things around as necessary.