### PR TITLE
Added missing module to cabal file

### DIFF
--- a/reflex-dom.cabal
+++ b/reflex-dom.cabal
@@ -106,6 +106,7 @@ library
     Reflex.Dom.Widget.Resize
     Reflex.Dom.Xhr
   other-modules:
+    Reflex.Dom.Builder.Class.TH
     Reflex.Dom.WebSocket.Foreign
     Reflex.Dom.Xhr.Foreign
     Reflex.Dom.Xhr.ResponseType


### PR DESCRIPTION
Currently e.g. stack outputs a warning like:
```
Warning: The following modules should be added to exposed-modules or other-modules in /home/qrilka/ws/h/reflex-huge-table/.stack-work/downloaded/G129R_XZQgTL/reflex-dom.cabal:
    - In the library component:
        Reflex.Dom.Builder.Class.TH

Missing modules in the cabal file are likely to cause undefined reference errors from the linker, along with other problems.
```