### PR TITLE
info on elDynAttrNS' tag

### DIFF
--- a/Quickref.md
+++ b/Quickref.md
@@ -36,7 +36,7 @@ Widgets may return any type (this is 'a' in many of the functions below).  Often
 [W]   elDynAttr  :: Text ->   Dynamic (Map Text Text) ->     m a -> m a
 [W]   elDynAttr' :: Text ->   Dynamic (Map Text Text) ->     m a -> m (El, a)
 
--- As above, but now there is an attribute namespace (e.g. xmlns )
+-- As above, but with an optional XML namespace for the tag.  Note that this does *not* set the 'xmlns' attribute.  See https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-DocCrElNS
 [W]   elDynAttrNS' :: Maybe Text -> Text -> Dynamic (Map Text Text) -> m a -> m (El, a)
 
 -- Shortcut for elAttr when you only want to set the "class" attribute.

--- a/Quickref.md
+++ b/Quickref.md
@@ -36,6 +36,9 @@ Widgets may return any type (this is 'a' in many of the functions below).  Often
 [W]   elDynAttr  :: Text ->   Dynamic (Map Text Text) ->     m a -> m a
 [W]   elDynAttr' :: Text ->   Dynamic (Map Text Text) ->     m a -> m (El, a)
 
+-- As above, but now the is an attribute namespace (e.g. xmlns )
+[W]   elDynAttrNS' :: Maybe Text -> Text -> Dynamic (Map Text Text) -> m a -> m (El, a)
+
 -- Shortcut for elAttr when you only want to set the "class" attribute.
 [W]   elClass    :: Text ->                       Text ->    m a -> m a
 

--- a/Quickref.md
+++ b/Quickref.md
@@ -36,7 +36,7 @@ Widgets may return any type (this is 'a' in many of the functions below).  Often
 [W]   elDynAttr  :: Text ->   Dynamic (Map Text Text) ->     m a -> m a
 [W]   elDynAttr' :: Text ->   Dynamic (Map Text Text) ->     m a -> m (El, a)
 
--- As above, but now the is an attribute namespace (e.g. xmlns )
+-- As above, but now there is an attribute namespace (e.g. xmlns )
 [W]   elDynAttrNS' :: Maybe Text -> Text -> Dynamic (Map Text Text) -> m a -> m (El, a)
 
 -- Shortcut for elAttr when you only want to set the "class" attribute.


### PR DESCRIPTION
After discussion on StackOverflow [[1](http://stackoverflow.com/questions/38268962/a-single-svg-element-with-reflex-frp)] I learned about the `elDynAttrNS'` which does not appear in the [Quick Reference](https://github.com/reflex-frp/reflex-dom/blob/develop/Quickref.md).  One line fix.