### PR TITLE
ease up deps

### DIFF
--- a/reflex-dom.cabal
+++ b/reflex-dom.cabal
@@ -47,7 +47,7 @@ library
     containers == 0.5.*,
     data-default >= 0.5 && < 0.8,
     dependent-map == 0.2.*,
-    dependent-sum == 0.3.*,
+    dependent-sum >= 0.3 && < 0.5,
     dependent-sum-template >= 0.0.0.4 && < 0.1,
     directory == 1.2.*,
     exception-transformers == 0.4.*,


### PR DESCRIPTION
For latest stackage LTS to build reflex, reflex-dom you'll need dependent-sum 0.4 so ease up dependency to allow build