### PR TITLE
Use inAnimationFrame from ghcjs-dom.

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -51,7 +51,7 @@ library
     dependent-sum-template >= 0.0.0.4 && < 0.1,
     directory >= 1.2 && < 1.4,
     exception-transformers == 0.4.*,
-    ghcjs-dom >= 0.9.0.0 && < 0.10,
+    ghcjs-dom >= 0.9.1.0 && < 0.10,
     jsaddle >=0.9.0.0 && <0.10,
     -- keycode-0.2 has a bug on firefox
     keycode >= 0.2.1 && < 0.3,

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
@@ -208,27 +208,16 @@ runImmediateDomBuilderT
   -> ImmediateDomBuilderEnv t
   -> Chan [DSum (EventTriggerRef t) TriggerInvocation]
   -> m a
-runImmediateDomBuilderT (ImmediateDomBuilderT a) env eventChan = do
-  handlersMVar <- liftIO $ newMVar []
+runImmediateDomBuilderT (ImmediateDomBuilderT a) env eventChan =
   flip runTriggerEventT eventChan $ do
-    win <- DOM.currentWindowUnchecked
     rec (x, req) <- runRequesterT (runReaderT a env) rsp
-        rsp <- performEventAsync $ ffor req $ \rm f -> liftJSM $ runInAnimationFrame handlersMVar win f $
+        rsp <- performEventAsync $ ffor req $ \rm f -> liftJSM $ runInAnimationFrame f $
           DMap.traverseWithKey (\_ r -> Identity <$> r) rm
     return x
   where
-    runInAnimationFrame handlersMVar win f x = do
-      handlers <- liftIO $ takeMVar handlersMVar
-      when (null handlers) $ do
-        rec cb <- newRequestAnimationFrameCallbackSync $ \_ -> do
-              freeRequestAnimationFrameCallback cb
-              handlersToRun <- liftIO $ takeMVar handlersMVar
-              liftIO $ putMVar handlersMVar []
-              sequence_ (reverse handlersToRun)
-        void $ Window.requestAnimationFrame win cb
-      liftIO $ putMVar handlersMVar ((do
+    runInAnimationFrame f x = void . DOM.inAnimationFrame' $ \_ -> do
         v <- synchronously x
-        void . liftIO $ f v) : handlers)
+        void . liftIO $ f v
 
 class Monad m => HasDocument m where
   askDocument :: m Document


### PR DESCRIPTION
By using this function from ghcjs-dom we get the ghcjs-base
implementation that is simpler on ghcjs.  On ghc we get the new
jsaddle version that has the same optimization we have now, but
handlers are shared with anything else that uses `inAnimationFrame`.