### PR TITLE
Moves the collection management functions to `reflex`.

### DIFF
--- a/reflex-dom-core/src/Foreign/JavaScript/TH.hs
+++ b/reflex-dom-core/src/Foreign/JavaScript/TH.hs
@@ -136,7 +136,7 @@ instance PrimMonad m => PrimMonad (WithJSContextSingleton x m) where
   type PrimState (WithJSContextSingleton x m) = PrimState m
   primitive = lift . primitive
 
-instance MonadAdjust t m => MonadAdjust t (WithJSContextSingleton x m) where
+instance Adjustable t m => Adjustable t (WithJSContextSingleton x m) where
   runWithReplace a0 a' = WithJSContextSingleton $ runWithReplace (coerce a0) (coerceEvent a')
   traverseIntMapWithKeyWithAdjust f dm0 dm' = WithJSContextSingleton $ traverseIntMapWithKeyWithAdjust (\k v -> unWithJSContextSingleton $ f k v) (coerce dm0) (coerceEvent dm')
   traverseDMapWithKeyWithAdjust f dm0 dm' = WithJSContextSingleton $ traverseDMapWithKeyWithAdjust (\k v -> unWithJSContextSingleton $ f k v) (coerce dm0) (coerceEvent dm')

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -70,7 +70,7 @@ class Default (EventSpec d EventResult) => DomSpace d where
 
 -- | @'DomBuilder' t m@ indicates that @m@ is a 'Monad' capable of building
 -- dynamic DOM in the 'Reflex' timeline @t@
-class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), MonadAdjust t m) => DomBuilder t m | m -> t where
+class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), Adjustable t m) => DomBuilder t m | m -> t where
   type DomBuilderSpace m :: *
   textNode :: TextNodeConfig t -> m (TextNode (DomBuilderSpace m) t)
   default textNode :: ( MonadTrans f

--- a/reflex-dom-core/src/Reflex/Dom/Builder/InputDisabled.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/InputDisabled.hs
@@ -76,7 +76,7 @@ instance MonadReflexCreateTrigger t m => MonadReflexCreateTrigger t (InputDisabl
   newEventWithTrigger = lift . newEventWithTrigger
   newFanEventWithTrigger f = lift $ newFanEventWithTrigger f
 
-instance MonadAdjust t m => MonadAdjust t (InputDisabledT m) where
+instance Adjustable t m => Adjustable t (InputDisabledT m) where
   runWithReplace a0 a' = InputDisabledT $ runWithReplace (coerce a0) (coerceEvent a')
   traverseDMapWithKeyWithAdjust f dm0 dm' = InputDisabledT $ traverseDMapWithKeyWithAdjust (\k v -> runInputDisabledT $ f k v) (coerce dm0) (coerceEvent dm')
   traverseDMapWithKeyWithAdjustWithMove f dm0 dm' = InputDisabledT $ traverseDMapWithKeyWithAdjustWithMove (\k v -> runInputDisabledT $ f k v) (coerce dm0) (coerceEvent dm')

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -33,6 +33,7 @@ import Data.Dependent.Sum (DSum (..))
 import Data.Functor.Compose
 import Data.Functor.Constant
 import qualified Data.Map as Map
+import Data.Map.Misc (applyMap)
 import Data.Monoid
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -41,7 +42,6 @@ import Data.Tuple
 import GHC.Generics
 import Reflex.Class
 import Reflex.Dom.Builder.Class
-import Reflex.Dom.Widget.Basic (applyMap)
 import Reflex.Dynamic
 import Reflex.Host.Class
 import Reflex.PerformEvent.Base
@@ -122,7 +122,7 @@ instance MonadRef m => MonadRef (StaticDomBuilderT t m) where
 instance MonadAtomicRef m => MonadAtomicRef (StaticDomBuilderT t m) where
   atomicModifyRef r = lift . atomicModifyRef r
 
-type SupportsStaticDomBuilder t m = (Reflex t, MonadIO m, MonadHold t m, MonadFix m, PerformEvent t m, MonadReflexCreateTrigger t m, MonadRef m, Ref m ~ Ref IO, MonadAdjust t m)
+type SupportsStaticDomBuilder t m = (Reflex t, MonadIO m, MonadHold t m, MonadFix m, PerformEvent t m, MonadReflexCreateTrigger t m, MonadRef m, Ref m ~ Ref IO, Adjustable t m)
 
 data StaticDomSpace
 
@@ -146,7 +146,7 @@ instance DomSpace StaticDomSpace where
   type RawSelectElement StaticDomSpace = ()
   addEventSpecFlags _ _ _ _ = StaticEventSpec
 
-instance (Reflex t, MonadAdjust t m, MonadHold t m) => MonadAdjust t (StaticDomBuilderT t m) where
+instance (Reflex t, Adjustable t m, MonadHold t m) => Adjustable t (StaticDomBuilderT t m) where
   runWithReplace a0 a' = do
     e <- StaticDomBuilderT ask
     (result0, result') <- lift $ runWithReplace (runStaticDomBuilderT a0 e) (flip runStaticDomBuilderT e <$> a')
@@ -157,7 +157,7 @@ instance (Reflex t, MonadAdjust t m, MonadHold t m) => MonadAdjust t (StaticDomB
   traverseDMapWithKeyWithAdjustWithMove = hoistDMapWithKeyWithAdjust traverseDMapWithKeyWithAdjustWithMove mapPatchDMapWithMove
 
 hoistDMapWithKeyWithAdjust :: forall (k :: * -> *) v v' t m p.
-  ( MonadAdjust t m
+  ( Adjustable t m
   , MonadHold t m
   , PatchTarget (p k (Constant (Behavior t Builder))) ~ DMap k (Constant (Behavior t Builder))
   , Patch (p k (Constant (Behavior t Builder)))

--- a/reflex-dom-core/src/Reflex/Dom/Modals/Base.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Modals/Base.hs
@@ -106,7 +106,7 @@ instance MonadAtomicRef m => MonadAtomicRef (ModalsT t m) where
   {-# INLINABLE atomicModifyRef #-}
   atomicModifyRef r = lift . atomicModifyRef r
 
-instance (MonadAdjust t m, MonadHold t m, MonadFix m) => MonadAdjust t (ModalsT t m) where
+instance (Adjustable t m, MonadHold t m, MonadFix m) => Adjustable t (ModalsT t m) where
   runWithReplace a0 a' = ModalsT $ runWithReplace (unModalsT a0) (fmapCheap unModalsT a')
   traverseDMapWithKeyWithAdjust f dm0 dm' = ModalsT $ traverseDMapWithKeyWithAdjust (coerce f) dm0 dm'
   traverseDMapWithKeyWithAdjustWithMove f dm0 dm' = ModalsT $ traverseDMapWithKeyWithAdjustWithMove (coerce f) dm0 dm'

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -12,7 +11,6 @@
 {-# LANGUAGE TypeFamilies #-}
 module Reflex.Dom.Widget.Basic
   ( partitionMapBySetLT
-  , listHoldWithKey
   , ChildResult (..)
 
   -- * Displaying Values
@@ -23,21 +21,6 @@ module Reflex.Dom.Widget.Basic
   , dyn
   , widgetHold
   , untilReady
-
-  -- * Working with Maps
-  , diffMapNoEq
-  , diffMap
-  , applyMap
-  , mapPartitionEithers
-  , applyMapKeysSet
-
-  -- * Widgets on Collections
-  , listWithKey
-  , listWithKey'
-  , listWithKeyShallowDiff
-  , listViewWithKey
-  , selectViewListWithKey
-  , selectViewListWithKey_
 
   -- * Creating DOM Elements
   , el
@@ -55,10 +38,6 @@ module Reflex.Dom.Widget.Basic
   , elDynAttrNS'
   , dynamicAttributesToModifyAttributes
   , dynamicAttributesToModifyAttributesWithInitial
-
-  -- * List Utils
-  , list
-  , simpleList
 
   -- * Specific DOM Elements
   , Link (..)
@@ -83,6 +62,7 @@ module Reflex.Dom.Widget.Basic
   ) where
 
 import Reflex.Class
+import Reflex.Collection
 import Reflex.Dom.Builder.Class
 import Reflex.Dom.Class
 import Reflex.Dynamic
@@ -95,9 +75,9 @@ import Data.Align
 import Data.Default
 import Data.Either
 import Data.Foldable
-import Data.Functor.Misc
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Map.Misc
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -128,13 +108,6 @@ partitionMapBySetLT s m0 = Map.fromDistinctAscList $ go (Set.toAscList s) m0
                         else (Left h, lt) : go t geq
 
 newtype ChildResult t k a = ChildResult { unChildResult :: (a, Event t (Map k (Maybe (ChildResult t k a)))) }
-
-listHoldWithKey :: forall t m k v a. (Ord k, DomBuilder t m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> m a) -> m (Dynamic t (Map k a))
-listHoldWithKey m0 m' f = do
-  let dm0 = mapWithFunctorToDMap $ Map.mapWithKey f m0
-      dm' = fmap (PatchDMap . mapWithFunctorToDMap . Map.mapWithKey (\k v -> ComposeMaybe $ fmap (f k) v)) m'
-  (a0, a') <- sequenceDMapWithAdjust dm0 dm'
-  fmap dmapToMap . incrementalToDynamic <$> holdIncremental a0 a' --TODO: Move the dmapToMap to the righthand side so it doesn't get fully redone every time
 
 text :: DomBuilder t m => Text -> m ()
 text t = void $ textNode $ def & textNodeConfig_initialContents .~ t
@@ -181,107 +154,6 @@ untilReady :: (DomBuilder t m, PostBuild t m) => m a -> m b -> m (a, Event t b)
 untilReady a b = do
   postBuild <- getPostBuild
   runWithReplace a $ b <$ postBuild
-
-diffMapNoEq :: (Ord k) => Map k v -> Map k v -> Map k (Maybe v)
-diffMapNoEq olds news = flip Map.mapMaybe (align olds news) $ \case
-  This _ -> Just Nothing
-  These _ new -> Just $ Just new
-  That new -> Just $ Just new
-
-diffMap :: (Ord k, Eq v) => Map k v -> Map k v -> Map k (Maybe v)
-diffMap olds news = flip Map.mapMaybe (align olds news) $ \case
-  This _ -> Just Nothing
-  These old new
-    | old == new -> Nothing
-    | otherwise -> Just $ Just new
-  That new -> Just $ Just new
-
-applyMap :: Ord k => Map k (Maybe v) -> Map k v -> Map k v
-applyMap patch old = insertions `Map.union` (old `Map.difference` deletions)
-  where (deletions, insertions) = mapPartitionEithers $ maybeToEither <$> patch
-        maybeToEither = \case
-          Nothing -> Left ()
-          Just r -> Right r
-
-mapPartitionEithers :: Map k (Either a b) -> (Map k a, Map k b)
-mapPartitionEithers m = (fromLeft <$> ls, fromRight <$> rs)
-  where (ls, rs) = Map.partition isLeft m
-        fromLeft (Left l) = l
-        fromLeft _ = error "mapPartitionEithers: fromLeft received a Right value; this should be impossible"
-        fromRight (Right r) = r
-        fromRight _ = error "mapPartitionEithers: fromRight received a Left value; this should be impossible"
-
--- | Apply a map patch to a set
--- > applyMapKeysSet patch (Map.keysSet m) == Map.keysSet (applyMap patch m)
-applyMapKeysSet :: Ord k => Map k (Maybe v) -> Set k -> Set k
-applyMapKeysSet patch old = Map.keysSet insertions `Set.union` (old `Set.difference` Map.keysSet deletions)
-  where (insertions, deletions) = Map.partition isJust patch
-
---TODO: Something better than Dynamic t (Map k v) - we want something where the Events carry diffs, not the whole value
-listWithKey :: forall t k v m a. (Ord k, DomBuilder t m, PostBuild t m, MonadFix m, MonadHold t m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m a) -> m (Dynamic t (Map k a))
-listWithKey vals mkChild = do
-  postBuild <- getPostBuild
-  let childValChangedSelector = fanMap $ updated vals
-      -- We keep track of changes to children values in the mkChild function we pass to listHoldWithKey
-      -- The other changes we need to keep track of are child insertions and deletions. diffOnlyKeyChanges
-      -- keeps track of insertions and deletions but ignores value changes, since they're already accounted for.
-      diffOnlyKeyChanges olds news = flip Map.mapMaybe (align olds news) $ \case
-        This _ -> Just Nothing
-        These _ _ -> Nothing
-        That new -> Just $ Just new
-  rec sentVals :: Dynamic t (Map k v) <- foldDyn applyMap Map.empty changeVals
-      let changeVals :: Event t (Map k (Maybe v))
-          changeVals = attachWith diffOnlyKeyChanges (current sentVals) $ leftmost
-                         [ updated vals
-                         , tag (current vals) postBuild --TODO: This should probably be added to the attachWith, not to the updated; if we were using diffMap instead of diffMapNoEq, I think it might not work
-                         ]
-  listHoldWithKey Map.empty changeVals $ \k v ->
-    mkChild k =<< holdDyn v (select childValChangedSelector $ Const2 k)
-
-{-# DEPRECATED listWithKey' "listWithKey' has been renamed to listWithKeyShallowDiff; also, its behavior has changed to fix a bug where children were always rebuilt (never updated)" #-}
-listWithKey' :: (Ord k, DomBuilder t m, MonadFix m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> Event t v -> m a) -> m (Dynamic t (Map k a))
-listWithKey' = listWithKeyShallowDiff
-
--- | Display the given map of items (in key order) using the builder function provided, and update it with the given event.  'Nothing' update entries will delete the corresponding children, and 'Just' entries will create them if they do not exist or send an update event to them if they do.
-listWithKeyShallowDiff :: (Ord k, DomBuilder t m, MonadFix m, MonadHold t m) => Map k v -> Event t (Map k (Maybe v)) -> (k -> v -> Event t v -> m a) -> m (Dynamic t (Map k a))
-listWithKeyShallowDiff initialVals valsChanged mkChild = do
-  let childValChangedSelector = fanMap $ fmap (Map.mapMaybe id) valsChanged
-  sentVals <- foldDyn applyMap Map.empty $ fmap (fmap void) valsChanged
-  let relevantPatch patch _ = case patch of
-        Nothing -> Just Nothing -- Even if we let a Nothing through when the element doesn't already exist, this doesn't cause a problem because it is ignored
-        Just _ -> Nothing -- We don't want to let spurious re-creations of items through
-  listHoldWithKey initialVals (attachWith (flip (Map.differenceWith relevantPatch)) (current sentVals) valsChanged) $ \k v ->
-    mkChild k v $ select childValChangedSelector $ Const2 k
-
---TODO: Something better than Dynamic t (Map k v) - we want something where the Events carry diffs, not the whole value
--- | Create a dynamically-changing set of Event-valued widgets.
---   This is like listWithKey, specialized for widgets returning (Event t a).  listWithKey would return 'Dynamic t (Map k (Event t a))' in this scenario, but listViewWithKey flattens this to 'Event t (Map k a)' via 'switch'.
-listViewWithKey :: (Ord k, DomBuilder t m, PostBuild t m, MonadHold t m, MonadFix m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m (Event t a)) -> m (Event t (Map k a))
-listViewWithKey vals mkChild = switch . fmap mergeMap <$> listViewWithKey' vals mkChild
-
-listViewWithKey' :: (Ord k, DomBuilder t m, PostBuild t m, MonadHold t m, MonadFix m) => Dynamic t (Map k v) -> (k -> Dynamic t v -> m a) -> m (Behavior t (Map k a))
-listViewWithKey' vals mkChild = current <$> listWithKey vals mkChild
-
--- | Create a dynamically-changing set of widgets, one of which is selected at any time.
-selectViewListWithKey :: forall t m k v a. (DomBuilder t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m)
-  => Dynamic t k          -- ^ Current selection key
-  -> Dynamic t (Map k v)  -- ^ Dynamic key/value map
-  -> (k -> Dynamic t v -> Dynamic t Bool -> m (Event t a)) -- ^ Function to create a widget for a given key from Dynamic value and Dynamic Bool indicating if this widget is currently selected
-  -> m (Event t (k, a))        -- ^ Event that fires when any child's return Event fires.  Contains key of an arbitrary firing widget.
-selectViewListWithKey selection vals mkChild = do
-  let selectionDemux = demux selection -- For good performance, this value must be shared across all children
-  selectChild <- listWithKey vals $ \k v -> do
-    let selected = demuxed selectionDemux k
-    selectSelf <- mkChild k v selected
-    return $ fmap ((,) k) selectSelf
-  return $ switchPromptlyDyn $ leftmost . Map.elems <$> selectChild
-
-selectViewListWithKey_ :: forall t m k v a. (DomBuilder t m, Ord k, PostBuild t m, MonadHold t m, MonadFix m)
-  => Dynamic t k          -- ^ Current selection key
-  -> Dynamic t (Map k v)  -- ^ Dynamic key/value map
-  -> (k -> Dynamic t v -> Dynamic t Bool -> m (Event t a)) -- ^ Function to create a widget for a given key from Dynamic value and Dynamic Bool indicating if this widget is currently selected
-  -> m (Event t k)        -- ^ Event that fires when any child's return Event fires.  Contains key of an arbitrary firing widget.
-selectViewListWithKey_ selection vals mkChild = fmap fst <$> selectViewListWithKey selection vals mkChild
 
 -- | Create a DOM element
 -- > el "div" (text "Hello World")
@@ -379,15 +251,6 @@ dynamicAttributesToModifyAttributesWithInitial attrs0 d = do
 --------------------------------------------------------------------------------
 -- Copied and pasted from Reflex.Widget.Class
 --------------------------------------------------------------------------------
-
--- | Create a dynamically-changing set of widgets from a Dynamic key/value map.
---   Unlike the 'withKey' variants, the child widgets are insensitive to which key they're associated with.
-list :: (Ord k, DomBuilder t m, MonadHold t m, PostBuild t m, MonadFix m) => Dynamic t (Map k v) -> (Dynamic t v -> m a) -> m (Dynamic t (Map k a))
-list dm mkChild = listWithKey dm (\_ dv -> mkChild dv)
-
--- | Create a dynamically-changing set of widgets from a Dynamic list.
-simpleList :: (DomBuilder t m, MonadHold t m, PostBuild t m, MonadFix m) => Dynamic t [v] -> (Dynamic t v -> m a) -> m (Dynamic t [a])
-simpleList xs mkChild = fmap (fmap (map snd . Map.toList)) $ flip list mkChild $ fmap (Map.fromList . zip [(1::Int)..]) xs
 
 {-
 schedulePostBuild x = performEvent_ . (x <$) =<< getPostBuild

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
@@ -41,6 +41,7 @@ import GHCJS.DOM.HTMLTextAreaElement (HTMLTextAreaElement)
 import GHCJS.DOM.Types (MonadJSM, File, uncheckedCastTo)
 import qualified GHCJS.DOM.Types as DOM (HTMLElement(..), EventTarget(..))
 import Reflex.Class
+import Reflex.Collection
 import Reflex.Dom.Builder.Class
 import Reflex.Dom.Builder.Immediate
 import Reflex.Dom.Class

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Lazy.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Lazy.hs
@@ -7,6 +7,7 @@
 module Reflex.Dom.Widget.Lazy where
 
 import Reflex.Class
+import Reflex.Collection
 import Reflex.Dom.Builder.Class
 import Reflex.Dom.Builder.Immediate
 import Reflex.Dom.Class

--- a/reflex-dom/examples/sortableList.hs
+++ b/reflex-dom/examples/sortableList.hs
@@ -67,7 +67,7 @@ displayRedrawTime e = do
   text "Time: "
   dynText =<< holdDyn "not yet run" (T.pack . show <$> diff)
 
-simpleSortableList :: forall t m k v. (MonadHold t m, MonadFix m, MonadAdjust t m, Ord k) => (k -> v -> m ()) -> Map k v -> Event t (v -> v -> Ordering) -> Event t (v -> v -> Ordering) -> m ()
+simpleSortableList :: forall t m k v. (MonadHold t m, MonadFix m, Adjustable t m, Ord k) => (k -> v -> m ()) -> Map k v -> Event t (v -> v -> Ordering) -> Event t (v -> v -> Ordering) -> m ()
 simpleSortableList f m0 resortFunc resortSlowFunc = do
   rec let resortPatchFast = attachWith (flip patchThatSortsMapWith) (currentIncremental m) resortFunc
           redrawPatch :: Map k v -> (v -> v -> Ordering) -> PatchMapWithMove k v


### PR DESCRIPTION
Also deals with the renaming of `MonadAdjust` in `reflex`.  There is a companion PR against `reflex` [here](https://github.com/reflex-frp/reflex/pull/121).