### PR TITLE
Moves Workflow across to reflex

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -26,6 +26,7 @@
 module Reflex.Dom.Builder.Class
        ( module Reflex.Dom.Builder.Class
        , module Reflex.Dom.Builder.Class.Events
+       , module Reflex.NotReady.Class
        ) where
 
 import Reflex.Class as Reflex
@@ -35,6 +36,7 @@ import Reflex.Dom.Builder.Class.TH
 #endif
 import Reflex.DynamicWriter
 import Reflex.EventWriter
+import Reflex.NotReady.Class
 import Reflex.PerformEvent.Class
 import Reflex.PostBuild.Base
 import Reflex.Query.Base
@@ -70,7 +72,7 @@ class Default (EventSpec d EventResult) => DomSpace d where
 
 -- | @'DomBuilder' t m@ indicates that @m@ is a 'Monad' capable of building
 -- dynamic DOM in the 'Reflex' timeline @t@
-class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), Adjustable t m) => DomBuilder t m | m -> t where
+class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable t m) => DomBuilder t m | m -> t where
   type DomBuilderSpace m :: *
   textNode :: TextNodeConfig t -> m (TextNode (DomBuilderSpace m) t)
   default textNode :: ( MonadTrans f
@@ -140,20 +142,6 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), Adjustable t m) => DomBu
     { _rawElementConfig_eventSpec = _rawElementConfig_eventSpec cfg
     }
   {-# INLINABLE wrapRawElement #-}
-  notReadyUntil :: Event t a -> m ()
-  default notReadyUntil :: ( MonadTrans f
-                           , m ~ f m'
-                           , DomBuilder t m'
-                           )
-                        => Event t a -> m ()
-  notReadyUntil = lift . notReadyUntil
-  notReady :: m ()
-  default notReady :: ( MonadTrans f
-                      , m ~ f m'
-                      , DomBuilder t m'
-                      )
-                   => m ()
-  notReady = lift notReady
 
 class DomBuilder t m => MountableDomBuilder t m where
   type DomFragment m :: *

--- a/reflex-dom-core/src/Reflex/Dom/Builder/InputDisabled.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/InputDisabled.hs
@@ -81,6 +81,10 @@ instance Adjustable t m => Adjustable t (InputDisabledT m) where
   traverseDMapWithKeyWithAdjust f dm0 dm' = InputDisabledT $ traverseDMapWithKeyWithAdjust (\k v -> runInputDisabledT $ f k v) (coerce dm0) (coerceEvent dm')
   traverseDMapWithKeyWithAdjustWithMove f dm0 dm' = InputDisabledT $ traverseDMapWithKeyWithAdjustWithMove (\k v -> runInputDisabledT $ f k v) (coerce dm0) (coerceEvent dm')
 
+instance NotReady t m => NotReady t (InputDisabledT m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
 instance DomBuilder t m => DomBuilder t (InputDisabledT m) where
   type DomBuilderSpace (InputDisabledT m) = DomBuilderSpace m
   inputElement cfg = lift $ inputElement $ cfg

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -189,6 +189,10 @@ hoistDMapWithKeyWithAdjust base mapPatch f dm0 dm' = do
       sample o
   return (result0, result')
 
+instance SupportsStaticDomBuilder t m => NotReady t (StaticDomBuilderT t m) where
+  notReadyUntil _ = pure ()
+  notReady = pure ()
+
 -- TODO: the uses of illegal lenses in this instance causes it to be somewhat less efficient than it can be. replacing them with explicit cases to get the underlying Maybe Event and working with those is ideal.
 instance SupportsStaticDomBuilder t m => DomBuilder t (StaticDomBuilderT t m) where
   type DomBuilderSpace (StaticDomBuilderT t m) = StaticDomSpace
@@ -277,8 +281,6 @@ instance SupportsStaticDomBuilder t m => DomBuilder t (StaticDomBuilderT t m) wh
     return (wrapped, result)
   placeRawElement () = return ()
   wrapRawElement () _ = return $ Element (EventSelector $ const never) ()
-  notReadyUntil _ = return () --TODO: Do we need to support this somehow?
-  notReady = return () --TODO: Do we need to support this somehow?
 
 --TODO: Make this more abstract --TODO: Put the WithWebView underneath PerformEventT - I think this would perform better
 type StaticWidget x = PostBuildT Spider (StaticDomBuilderT Spider (PerformEventT Spider (SpiderHost Global)))


### PR DESCRIPTION
This also included moving generalizations of `dyn` and `widgetHold` across to `reflex` and breaking out a `NotReady` class from the `DomBuilder` class.

There is a companion PR in the `reflex` repository [here](https://github.com/reflex-frp/reflex/pull/138).