### PR TITLE
jsaddle-warp support for `run` and friends

### DIFF
--- a/reflex-dom/default.nix
+++ b/reflex-dom/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, base, bytestring, jsaddle-webkit2gtk, jsaddle-wkwebview, reflex
+{ mkDerivation, base, bytestring, jsaddle-webkit2gtk, jsaddle-wkwebview, jsaddle-warp, reflex
 , reflex-dom-core, stdenv, text, ghc, hostPlatform, jsaddle-clib, android-activity ? null
 }:
 let isAndroid = hostPlatform.libc == "bionic";
@@ -11,11 +11,13 @@ in mkDerivation {
   ] ++ (if ghc.isGhcjs or false then [
   ] else if hostPlatform.isDarwin then [
     jsaddle-wkwebview
+    jsaddle-warp
   ] else if isAndroid then [
     jsaddle-clib
     android-activity
   ] else [
     jsaddle-webkit2gtk
+    jsaddle-warp
   ]);
   configureFlags = if isAndroid then [ "-fandroid" ] else [];
   description = "Functional Reactive Web Apps with Reflex";

--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -17,6 +17,10 @@ extra-source-files: src/Reflex/Dom/Xhr/Foreign.hs
                     src/Reflex/Dom/Xhr/Exception.hs
                     java/org/reflexfrp/reflexdom/MainWidget.java
 
+flag use-warp
+  description: Use jsaddle-warp server
+  default: True
+
 flag webkit2gtk
   description: Use WebKit2 version of WebKitGTK.
   default: True
@@ -68,13 +72,18 @@ library
         jsaddle,
         jsaddle-wkwebview
     else
-      if flag(webkit2gtk)
+      if flag(use-warp)
         build-depends:
-          jsaddle-webkit2gtk
+          jsaddle,
+          jsaddle-warp
       else
-        if !flag(android)
+        if flag(webkit2gtk)
           build-depends:
-            jsaddle-webkitgtk
+            jsaddle-webkit2gtk
+        else
+          if !flag(android)
+            build-depends:
+              jsaddle-webkit2gtk
 
   exposed-modules:
     Reflex.Dom

--- a/reflex-dom/src/Reflex/Dom/Internal.hs
+++ b/reflex-dom/src/Reflex/Dom/Internal.hs
@@ -20,6 +20,18 @@ import qualified Reflex.Dom.Main as Main
 #if defined(ghcjs_HOST_OS)
 run :: a -> a
 run = id
+#elif defined(MIN_VERSION_jsaddle_warp)
+import Data.Maybe (maybe)
+import Data.Monoid ((<>))
+import Language.Javascript.JSaddle (JSM)
+import qualified Language.Javascript.JSaddle.Warp as JW
+import System.Environment (lookupEnv)
+
+run :: JSM () -> IO()
+run jsm = do
+  port <- maybe 3003 read <$> lookupEnv "JSADDLE_WARP_PORT"
+  putStrLn $ "Running jsaddle-warp server on port " <> show port
+  JW.run port jsm
 #elif defined(MIN_VERSION_jsaddle_wkwebview)
 import Language.Javascript.JSaddle.WKWebView (runFile)
 import Language.Javascript.JSaddle (JSM)


### PR DESCRIPTION
I'm new to Reflex, feel free to provide any feedback. This change was originally motivated by [this](https://github.com/reflex-frp/reflex-platform/pull/222#issuecomment-360186869) [discussion](https://github.com/reflex-frp/reflex-platform/pull/227#issuecomment-361451491).

It enables the use of jsaddle-warp as default when compiled with GHC.

---

The flag `use-warp` controls this. Because it is enabled by default,
the user would see a warp server in place of webkit/gtk frontend
when when compiling the frontend in GHC.

Port number for the warp server is determined from the environment
variable `JSADDLE_WARP_PORT`, with a default value of 3003. The
port number will be printed to stdout by `run` so that user would
know where they can access the app.