### PR TITLE
Handle external urls from WebView

### DIFF
--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -23,6 +23,8 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import java.io.IOException;
 import java.io.InputStream;
+import android.content.Intent;
+
 import java.nio.charset.StandardCharsets;
 
 public class MainWidget {
@@ -73,6 +75,17 @@ public class MainWidget {
 
             return null;
         }
+
+        @Override
+        public boolean shouldOverrideUrlLoading(WebView view, String url) {
+            if( url != null && !url.startsWith("http://") && !url.startsWith("https://") && !url.startsWith("file://")) {
+                view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                return true;
+            } else {
+                return false;
+            }
+        }
+
     });
 
     wv.setWebChromeClient(new WebChromeClient() {


### PR DESCRIPTION
We simply forward everything that is not https:// http:// or file:// to Android.

Are there any better ways for knowing what URI schemes should be opened in the WebView directly? 

This PR makes links like whatsapp:// or tg:// sms:// mailto:// and similar work, as the webview does not know how to handle them. We make them work, by simply passing them on to Android.