### PR TITLE
use-warp should be disabled by default

### DIFF
--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -19,7 +19,8 @@ extra-source-files: src/Reflex/Dom/Xhr/Foreign.hs
 
 flag use-warp
   description: Use jsaddle-warp server
-  default: True
+  default: False
+  manual: True
 
 flag webkit2gtk
   description: Use WebKit2 version of WebKitGTK.


### PR DESCRIPTION
For backwards compatibility with things that rely on webkit2gtk
being the default backend with ghc.

Addresses https://github.com/reflex-frp/reflex-platform/issues/231#issuecomment-362597152