### PR TITLE
Ask user for permissions.

### DIFF
--- a/reflex-dom/cbits/MainWidget.c
+++ b/reflex-dom/cbits/MainWidget.c
@@ -15,7 +15,7 @@ jobject Reflex_Dom_Android_MainWidget_start(jobject activity, const char *url, c
 
   jclass cls = (*env)->FindClass(env, "org/reflexfrp/reflexdom/MainWidget");
   assert(cls);
-  jmethodID startMainWidget = (*env)->GetStaticMethodID(env, cls, "startMainWidget", "(Landroid/app/Activity;Ljava/lang/String;JLjava/lang/String;)Ljava/lang/Object;");
+  jmethodID startMainWidget = (*env)->GetStaticMethodID(env, cls, "startMainWidget", "(Lsystems/obsidian/HaskellActivity;Ljava/lang/String;JLjava/lang/String;)Ljava/lang/Object;");
   assert(startMainWidget);
 
   jstring jurl = (*env)->NewStringUTF(env, url);

--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -1,7 +1,6 @@
 package org.reflexfrp.reflexdom;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
@@ -25,8 +24,10 @@ import android.content.Intent;
 
 import java.nio.charset.StandardCharsets;
 
+import systems.obsidian.HaskellActivity;
+
 public class MainWidget {
-  private static Object startMainWidget(final Activity a, String url, long jsaddleCallbacks, final String initialJS) {
+  private static Object startMainWidget(final HaskellActivity a, String url, long jsaddleCallbacks, final String initialJS) {
     CookieManager.setAcceptFileSchemeCookies(true); //TODO: Can we do this just for our own WebView?
 
     // Remove title and notification bars
@@ -90,19 +91,18 @@ public class MainWidget {
         // Need to accept permissions to use the camera and audio
         @Override
         public void onPermissionRequest(final PermissionRequest request) {
-            a.runOnUiThread(new Runnable() {
-                @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-                @Override
-                public void run() {
-                    // Make sure the request is coming from the file system ...
-                    if(request.getOrigin().toString().startsWith("file://")) {
-                        request.grant(request.getResources());
-                    }
-                    else {
-                        request.deny();
-                    }
-                }
-            });
+            if(request.getOrigin().toString().startsWith("file://")) {
+                a.requestWebViewPermissions(request);
+            }
+            else {
+                a.runOnUiThread(new Runnable() {
+                        @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+                        @Override
+                        public void run() {
+                            request.deny();
+                        }
+                    });
+            }
         }
 
         @Override


### PR DESCRIPTION
From Android 6 on we have to ask for permissions at runtime. This commit
together with the [PR](https://github.com/reflex-frp/reflex-platform/pull/242) for the reflex-platform asks the user for permission for
accessing camera and microphone as it is required from Android 6 onwards.

When the Webview asks for permissions, we check whether we have the
corresponding Manifest permissions - if so, we simply grant the request. If not
we ask the user for permission. The implementation is also compatible with
Android 5 as we simply grant access in that case.

The split up into a PR for reflex-dom and reflex-platform is unfortunately
necessary because of the way we get the user's answer in Java: By means of an
overriden method of Activity.