### PR TITLE
Don't crash if URI cannot be handled by Android.

### DIFF
--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -79,7 +79,12 @@ public class MainWidget {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
             if( url != null && !url.startsWith("http://") && !url.startsWith("https://") && !url.startsWith("file://")) {
-                view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                try {
+                    view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                }
+                catch(Exception e) {
+                    Log.e("reflex", "Starting activity for intent '" + url + "' failed!");
+                }
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Instead the request is simply ignored, which is not ideal, but definitely better
than a crash.

This affects application uris like whatsapp:// - if WhatsApp was not installed,
the application would crash on such an URI.