### PR TITLE
ghcjs-dom upper version bound adjusted

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -56,7 +56,7 @@ library
     dependent-sum-template >= 0.0.0.4 && < 0.1,
     directory >= 1.2 && < 1.4,
     exception-transformers == 0.4.*,
-    ghcjs-dom >= 0.9.1.0 && < 0.10,
+    ghcjs-dom >= 0.9.1.0 && < 0.9.4,
     jsaddle >=0.9.0.0 && <0.10,
     -- keycode-0.2 has a bug on firefox
     keycode >= 0.2.1 && < 0.3,


### PR DESCRIPTION
I ran into a problem using ghcjs-dom-0.9.4.0. The problem I had is documented here: 

https://stackoverflow.com/questions/51258483/getanddecoderesponseevent-runs-3-times-instead-of-just-once/51269216#51269216

Using ghcjs-dom-0.9.3.0 resolved it.

I hope with this PR I can be of help!