### PR TITLE
allow aeson 1.3.x

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -41,7 +41,7 @@ flag profile-reflex
 library
   hs-source-dirs: src
   build-depends:
-    aeson >= 0.8 && < 1.3,
+    aeson >= 0.8 && < 1.4,
     base >= 4.7 && < 4.12,
     bifunctors >= 4.2 && < 6,
     bimap >= 0.3 && < 0.4,


### PR DESCRIPTION
allow aeson 1.3.x  (in order to be compatible with stack lts-12.3)