### PR TITLE
[wip] Update for latest reflex

### DIFF
--- a/reflex-dom-core/src/Foreign/JavaScript/TH.hs
+++ b/reflex-dom-core/src/Foreign/JavaScript/TH.hs
@@ -36,6 +36,7 @@ import Reflex.PerformEvent.Class
 import Reflex.PostBuild.Base
 import Reflex.Requester.Base
 import Reflex.Query.Base (QueryT (..))
+import Reflex.Adjustable.Class
 
 #ifdef USE_TEMPLATE_HASKELL
 import Language.Haskell.TH

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -42,6 +42,7 @@ import Reflex.PostBuild.Base
 import Reflex.Query.Base
 import Reflex.Query.Class
 import Reflex.Requester.Base
+import Reflex.Adjustable.Class
 
 import qualified Control.Category
 import Control.Lens hiding (element)

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
@@ -105,6 +105,7 @@ import Reflex.TriggerEvent.Base hiding (askEvents)
 import qualified Reflex.TriggerEvent.Base as TriggerEventT (askEvents)
 import Reflex.TriggerEvent.Class
 import Reflex.Query.Base (QueryT)
+import Reflex.Adjustable.Class
 
 import Control.Concurrent
 import Control.Lens hiding (element, ix)

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -49,6 +49,7 @@ import Reflex.PerformEvent.Class
 import Reflex.PostBuild.Base
 import Reflex.Spider
 import Reflex.TriggerEvent.Class
+import Reflex.Adjustable.Class
 
 data StaticDomBuilderEnv t = StaticDomBuilderEnv
   { _staticDomBuilderEnv_shouldEscape :: Bool


### PR DESCRIPTION
The Adjustable change is pretty straightforward. It just uses the new Reflex.Adjustable.Class module that has just been added to reflex.

The HasDocument instance can probably be fixed, but I have't found a way to do it. Here is the error I get with this instance:

```
I cannot find a good way to right an instance for HasDocument. Here is
the previous error this fixes:

src/Reflex/Dom/Builder/Static.hs:152:17-23: error:
    • Couldn't match type ‘RawDocument
                             (DomBuilderSpace (StaticDomBuilderT t m))’
                     with ‘()’
      Expected type: StaticDomBuilderT
                       t m (RawDocument (DomBuilderSpace (StaticDomBuilderT t m)))
        Actual type: StaticDomBuilderT t m ()
    • In the expression: pure ()
      In an equation for ‘askDocument’: askDocument = pure ()
      In the instance declaration for
        ‘HasDocument (StaticDomBuilderT t m)’
    • Relevant bindings include
        askDocument :: StaticDomBuilderT
                         t m (RawDocument (DomBuilderSpace (StaticDomBuilderT t m)))
          (bound at src/Reflex/Dom/Builder/Static.hs:152:3)
    |
152 |   askDocument = pure ()
    |                 ^^^^^^^
```