### PR TITLE
Fix iOS baseUrl

### DIFF
--- a/reflex-dom/src/Reflex/Dom/Internal.hs
+++ b/reflex-dom/src/Reflex/Dom/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -32,7 +33,25 @@ run jsm = do
   putStrLn $ "Running jsaddle-warp server on port " <> show port
   JW.run port jsm
 #elif defined(MIN_VERSION_jsaddle_wkwebview)
+#if defined(ios_HOST_OS)
+import Data.Default
+import Language.Javascript.JSaddle (JSM)
+import Language.Javascript.JSaddle.WKWebView (run', mainBundleResourcePath)
+import Language.Javascript.JSaddle.WKWebView.Internal (jsaddleMainHTMLWithBaseURL)
+
+-- TODO: upstream to jsaddle-wkwebview
+run :: JSM () -> IO ()
+run jsm = do
+  let indexHtml = "<!DOCTYPE html><html><head></head><body></body></html>"
+  baseUrl <- mainBundleResourcePath >>= \case
+    Nothing -> do
+      putStrLn "Reflex.Dom.run: unable to find main bundle resource path. Assets may not load properly."
+      return ""
+    Just p -> return $ "file://" <> p <> "/index.html"
+  run' def $ jsaddleMainHTMLWithBaseURL indexHtml baseUrl jsm
+#else
 import Language.Javascript.JSaddle.WKWebView (run)
+#endif
 #elif defined(ANDROID)
 import Android.HaskellActivity
 import Control.Monad


### PR DESCRIPTION
This change only affects iOS which was failing to find assets relative
to the main bundle resource path which is the expected location for the
it to be placed.

TODO: upstream this to jsaddle-wkwebview