### PR TITLE
Add commentNode to DomBuilder

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -16,6 +16,8 @@ module Reflex.Dom.Widget.Basic
   -- * Displaying Values
   , text
   , dynText
+  , comment
+  , dynComment
   , display
   , button
   , dyn
@@ -115,6 +117,19 @@ dynText :: forall t m. (PostBuild t m, DomBuilder t m) => Dynamic t Text -> m ()
 dynText t = do
   postBuild <- getPostBuild
   void $ textNode $ (def :: TextNodeConfig t) & textNodeConfig_setContents .~ leftmost
+    [ updated t
+    , tag (current t) postBuild
+    ]
+  notReadyUntil postBuild
+
+comment :: DomBuilder t m => Text -> m ()
+comment t = void $ commentNode $ def & commentNodeConfig_initialContents .~ t
+
+{-# INLINABLE dynComment #-}
+dynComment :: forall t m. (PostBuild t m, DomBuilder t m) => Dynamic t Text -> m ()
+dynComment t = do
+  postBuild <- getPostBuild
+  void $ commentNode $ (def :: CommentNodeConfig t) & commentNodeConfig_setContents .~ leftmost
     [ updated t
     , tag (current t) postBuild
     ]


### PR DESCRIPTION
Perhaps we should use a more obscure name for `comment`, given that it probably won't have much usage in the wild. Maybe it doesn't even need to be in `Widget.Basic`.