### PR TITLE
widgetReady (untilReady reexport)

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -22,6 +22,8 @@ module Reflex.Dom.Widget.Basic
   , dyn_
   , widgetHold
   , widgetHold_
+  , widgetReady
+  , widgetReady_
 
   -- * Creating DOM Elements
   , el
@@ -149,6 +151,16 @@ widgetHold = networkHold
 -- | Like 'widgetHold' but discards result.
 widgetHold_ :: (DomBuilder t m, MonadHold t m) => m a -> Event t (m a) -> m ()
 widgetHold_ z = void . widgetHold z
+
+-- | Given widget 'a' and widget 'b', render widget a until widget b's postBuild event fires.
+--   This is useful for example when widget b takes too long to render, but you still want to render
+--   something in its place (say, a loading animation)
+widgetReady :: (Adjustable t m, PostBuild t m) => m a -> m b -> m (a, Event t b)
+widgetReady = untilReady
+
+-- | Like 'widgetReady', but discards the result.
+widgetReady_ :: (Adjustable t m, PostBuild t m) => m a -> m b -> m ()
+widgetReady_ = void . untilReady
 
 -- | Create a DOM element
 -- > el "div" (text "Hello World")


### PR DESCRIPTION
reflex exports [this function ](https://github.com/reflex-frp/reflex/blob/develop/src/Reflex/Network.hs)
```haskell
-- | Render a placeholder network to be shown while another network is not yet
-- done building
untilReady :: (Adjustable t m, PostBuild t m) => m a -> m b -> m (a, Event t b)
untilReady a b = do
  postBuild <- getPostBuild
  runWithReplace a $ b <$ postBuild
```
it's pretty simple, but despite me pouring over tons of reflex-dom/reflex code / documentation i don't see anyone using it or reimplementing it in any form. primarily, i use this for displaying a loading dimmer on pages where the javascript takes a few seconds to render everything. i think it would be useful for reflex-dom to reexport and document this function, in the same vein as ```dyn``` or ```widgetHold```