### PR TITLE
Fix race condition in websocket connection / registration of callbacks

### DIFF
--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
 import android.webkit.CookieManager;
+import android.webkit.GeolocationPermissions;
 import android.webkit.JavascriptInterface;
 import android.webkit.MimeTypeMap;
 import android.webkit.PermissionRequest;
@@ -41,6 +42,7 @@ public class MainWidget {
     ws.setAllowFileAccessFromFileURLs(true);
     ws.setAllowUniversalAccessFromFileURLs(true);
     ws.setDomStorageEnabled(true);
+    ws.setGeolocationEnabled(true);
     wv.setWebContentsDebuggingEnabled(true);
     // allow video to play without user interaction
     wv.getSettings().setMediaPlaybackRequiresUserGesture(false);
@@ -108,6 +110,11 @@ public class MainWidget {
         @Override
         public Bitmap getDefaultVideoPoster() {
             return Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+        }
+
+        @Override
+        public void onGeolocationPermissionsShowPrompt (String origin, GeolocationPermissions.Callback callback) {
+          callback.invoke(origin, true, true);
         }
     });
 


### PR DESCRIPTION
Before this patch, it was possible that `newWebSocket` would initiate a connection and hit an error before the error handler had been registered. It was also possible to attempt to send a message when the `readyState` was not `1` (open).

This PR can be separated from the Geolocation stuff in 24d2e99  - not sure if there's already a PR for that or if that should go in as-is.