### PR TITLE
addGcTestDepends should noop on cross and ghcjs

### DIFF
--- a/reflex-dom-core/default.nix
+++ b/reflex-dom-core/default.nix
@@ -7,7 +7,7 @@
 , unix, zenc, hashable, chromium, process, jsaddle-warp
 , linux-namespaces, iproute, network-uri, fontconfig
 }:
-let addGcTestDepends = drv: if stdenv.system != "x86_64-linux" then drv else drv // {
+let addGcTestDepends = drv: if (stdenv.system != "x86_64-linux" || stdenv.hostPlatform != stdenv.buildPlatform || (ghc.isGhcjs or false)) then drv else drv // {
       # The headless browser run as part of gc tests would hang/crash without this
       preCheck = ''
         export FONTCONFIG_PATH=${fontconfig.out}/etc/fonts


### PR DESCRIPTION
to match the plaform for which it is buildable