### PR TITLE
Lift Prerender method constraints onto class instead

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -166,6 +166,7 @@ test-suite hydration
                , filepath
                , ghcjs-dom
                , hspec
+               , hspec-core
                , hspec-webdriver
                , http-types
                , HUnit

--- a/reflex-dom-core/src/Foreign/JavaScript/TH.hs
+++ b/reflex-dom-core/src/Foreign/JavaScript/TH.hs
@@ -291,10 +291,12 @@ class Monad m => MonadJS x m | m -> x where
   getJSProp :: String -> JSRef x -> m (JSRef x)
   withJSNode :: Node -> (JSRef x -> m r) -> m r
 
+type HasJS' = HasJS JS'
+
 #ifdef ghcjs_HOST_OS
 
 data JSCtx_IO
-type HasJS' = HasJS JSCtx_IO
+type JSX = JSCtx_IO
 
 instance MonadIO m => HasJS JSCtx_IO (WithJSContextSingleton x m) where
   type JSX (WithJSContextSingleton x m) = IO
@@ -345,7 +347,7 @@ foreign import javascript unsafe "function(){ return $1(arguments); }" funWithAr
 #else
 
 data JSCtx_JavaScriptCore x
-type HasJS' = HasJS (JSCtx_JavaScriptCore ())
+type JS' = JSCtx_JavaScriptCore ()
 
 instance IsJSContext (JSCtx_JavaScriptCore x) where
   newtype JSRef (JSCtx_JavaScriptCore x) = JSRef_JavaScriptCore { unJSRef_JavaScriptCore :: JSVal }

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -52,7 +52,6 @@ type PrerenderClientConstraint js t m =
   , DomRenderHook t m
   , HasDocument m
   , TriggerEvent t m
-  -- , Prerender js t m
   , PrerenderBaseConstraints js t m
   )
 

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -24,7 +24,7 @@ module Reflex.Dom.Prerender
        , PrerenderBaseConstraints
        ) where
 
-import Control.Monad.Primitive (PrimMonad)
+import Control.Monad.Primitive (PrimMonad(..))
 import Control.Monad.Reader
 import Control.Monad.Ref (MonadRef(..))
 import Data.IORef (IORef, newIORef)
@@ -170,28 +170,58 @@ instance Monad m => MonadRef (UnrunnableT js t m) where
 instance Monad m => HasDocument (UnrunnableT js t m) where
   askDocument = unrunnable
 instance Monad m => HasJSContext (UnrunnableT js t m) where
-  --type JsContextPhantom (UnrunnableT js t m) = ()
+  type JSContextPhantom (UnrunnableT js t m) = ()
+  askJSContext = unrunnable
 instance Monad m => HasJS JS' (UnrunnableT js t m) where
   type JSX (UnrunnableT js t m) = UnrunnableT js t m
+  liftJS _ = unrunnable
 instance Monad m => MonadJS JS' (UnrunnableT js t m) where
+  runJS _ _ = unrunnable
+  forkJS _ = unrunnable
+  mkJSUndefined = unrunnable
+  isJSNull _ = unrunnable
+  isJSUndefined _ = unrunnable
+  fromJSBool _ = unrunnable
+  fromJSString _ = unrunnable
+  fromJSArray _ = unrunnable
+  fromJSUint8Array _ = unrunnable
+  fromJSNumber _ = unrunnable
+  withJSBool _ _ = unrunnable
+  withJSString _ _ = unrunnable
+  withJSNumber _ _ = unrunnable
+  withJSArray _ _ = unrunnable
+  withJSUint8Array _ _ = unrunnable
+  mkJSFun _ = unrunnable
+  freeJSFun _ = unrunnable
+  setJSProp _ _ _ = unrunnable
+  getJSProp _ _ = unrunnable
+  withJSNode _ _ = unrunnable
 instance Monad m => TriggerEvent t (UnrunnableT js t m) where
+  newTriggerEvent = unrunnable
+  newTriggerEventWithOnComplete = unrunnable
+  newEventWithLazyTriggerWithOnComplete _ = unrunnable
 instance Monad m => MonadReflexCreateTrigger t (UnrunnableT js t m) where
   newEventWithTrigger _ = unrunnable
+  newFanEventWithTrigger _ = unrunnable
 instance Monad m => MonadFix (UnrunnableT js t m) where
   mfix _ = unrunnable
 instance Monad m => MonadHold t (UnrunnableT js t m) where
   hold _ _ = unrunnable
   holdDyn _ _ = unrunnable
   holdIncremental _ _ = unrunnable
-instance Monad m => MonadSample t (UnrunnableT js t m)
-instance Monad m => MonadIO (UnrunnableT js t m)
+  buildDynamic _ _ = unrunnable
+  headE _ = unrunnable
+instance Monad m => MonadSample t (UnrunnableT js t m) where
+  sample _ = unrunnable
+instance Monad m => MonadIO (UnrunnableT js t m) where
+  liftIO _ = unrunnable
 instance Monad m => MonadJSM (UnrunnableT js t m) where
   liftJSM' _ = unrunnable
-instance (Reflex t, Monad m) => PostBuild t (UnrunnableT js t m)
+instance (Reflex t, Monad m) => PostBuild t (UnrunnableT js t m) where
+  getPostBuild = unrunnable
 instance Monad m => PrimMonad (UnrunnableT js t m) where
---  type RawDocument (UnrunnableT js t m) = DOM.Document
---instance HasJSContext (UnrunnableT js t m)
---instance MonadJSM (UnrunnableT js t m)
+  type PrimState (UnrunnableT js t m) = PrimState IO
+  primitive _ = unrunnable
 instance (Reflex t, Monad m) => DomRenderHook t (UnrunnableT js t m) where
   withRenderHook _ _ = unrunnable
   requestDomAction _ = unrunnable

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -197,7 +197,11 @@ instance PrimMonad (UnrunnableT js t m) where
 --  type RawDocument (UnrunnableT js t m) = DOM.Document
 --instance HasJSContext (UnrunnableT js t m)
 --instance MonadJSM (UnrunnableT js t m)
-instance Prerender JS' t (UnrunnableT js t m) where
+instance Reflex t => DomRenderHook t (UnrunnableT js t m) where
+  withRenderHook _ _ = UnrunnableT $ \case
+  requestDomAction _ = UnrunnableT $ \case
+  requestDomAction_ _ = UnrunnableT $ \case
+instance Reflex t => Prerender JS' t (UnrunnableT js t m) where
   type Client (UnrunnableT js t m) = UnrunnableT js t m
   prerender _ _ = UnrunnableT $ \case
 

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -136,44 +136,47 @@ instance (Adjustable t m, PrerenderBaseConstraints js t m, ReflexHost t) => Prer
 
 newtype UnrunnableT js t m a = UnrunnableT { runUnrunnableT :: Void -> m a }
 
+unrunnable :: UnrunnableT js t m a
+unrunnable = UnrunnableT $ \case
+
 instance Functor (UnrunnableT js t m) where
-  fmap _ _ = UnrunnableT $ \case
+  fmap _ _ = unrunnable
 instance Applicative (UnrunnableT js t m) where
-  pure _ = UnrunnableT $ \case
-  _ <*> _ = UnrunnableT $ \case
+  pure _ = unrunnable
+  _ <*> _ = unrunnable
 instance Monad (UnrunnableT js t m) where
-  _ >>= _ = UnrunnableT $ \case
+  _ >>= _ = unrunnable
 instance MonadTrans (UnrunnableT js t) where
-  lift _ = UnrunnableT $ \case
+  lift _ = unrunnable
 instance Reflex t => DomBuilder t (UnrunnableT js t m) where
   type DomBuilderSpace (UnrunnableT js t m) = GhcjsDomSpace
-  textNode _ = UnrunnableT $ \case
-  commentNode _ = UnrunnableT $ \case
-  element _ _ _ = UnrunnableT $ \case
-  inputElement _ = UnrunnableT $ \case
-  textAreaElement _ = UnrunnableT $ \case
-  selectElement _ _ = UnrunnableT $ \case
-  placeRawElement _ = UnrunnableT $ \case
-  wrapRawElement _ _ = UnrunnableT $ \case
+  textNode _ = unrunnable
+  commentNode _ = unrunnable
+  element _ _ _ = unrunnable
+  inputElement _ = unrunnable
+  textAreaElement _ = unrunnable
+  selectElement _ _ = unrunnable
+  placeRawElement _ = unrunnable
+  wrapRawElement _ _ = unrunnable
 instance NotReady t (UnrunnableT js t m) where
-  notReadyUntil _ = UnrunnableT $ \case
-  notReady = UnrunnableT $ \case
+  notReadyUntil _ = unrunnable
+  notReady = unrunnable
 instance Reflex t => Adjustable t (UnrunnableT js t m) where
-  runWithReplace _ _ = UnrunnableT $ \case
-  traverseIntMapWithKeyWithAdjust _ _ _ = UnrunnableT $ \case
-  traverseDMapWithKeyWithAdjust _ _ _ = UnrunnableT $ \case
-  traverseDMapWithKeyWithAdjustWithMove _ _ _ = UnrunnableT $ \case
+  runWithReplace _ _ = unrunnable
+  traverseIntMapWithKeyWithAdjust _ _ _ = unrunnable
+  traverseDMapWithKeyWithAdjust _ _ _ = unrunnable
+  traverseDMapWithKeyWithAdjustWithMove _ _ _ = unrunnable
 instance Reflex t => PerformEvent t (UnrunnableT js t m) where
   type Performable (UnrunnableT js t m) = UnrunnableT js t m
-  performEvent _ = UnrunnableT $ \case
-  performEvent_ _ = UnrunnableT $ \case
+  performEvent _ = unrunnable
+  performEvent_ _ = unrunnable
 instance MonadRef (UnrunnableT js t m) where
   type Ref (UnrunnableT js t m) = Ref IO
-  newRef _ = UnrunnableT $ \case
-  readRef _ = UnrunnableT $ \case
-  writeRef _ _ = UnrunnableT $ \case
+  newRef _ = unrunnable
+  readRef _ = unrunnable
+  writeRef _ _ = unrunnable
 instance HasDocument (UnrunnableT js t m) where
-  askDocument = UnrunnableT $ \case
+  askDocument = unrunnable
 instance HasJSContext (UnrunnableT js t m) where
   --type JsContextPhantom (UnrunnableT js t m) = ()
 instance HasJS JS' (UnrunnableT js t m) where
@@ -181,29 +184,29 @@ instance HasJS JS' (UnrunnableT js t m) where
 instance MonadJS JS' (UnrunnableT js t m) where
 instance TriggerEvent t (UnrunnableT js t m) where
 instance MonadReflexCreateTrigger t (UnrunnableT js t m) where
-  newEventWithTrigger _ = UnrunnableT $ \case
+  newEventWithTrigger _ = unrunnable
 instance MonadFix (UnrunnableT js t m) where
-  mfix _ = UnrunnableT $ \case
+  mfix _ = unrunnable
 instance MonadHold t (UnrunnableT js t m) where
-  hold _ _ = UnrunnableT $ \case
-  holdDyn _ _ = UnrunnableT $ \case
-  holdIncremental _ _ = UnrunnableT $ \case
+  hold _ _ = unrunnable
+  holdDyn _ _ = unrunnable
+  holdIncremental _ _ = unrunnable
 instance MonadSample t (UnrunnableT js t m)
 instance MonadIO (UnrunnableT js t m)
 instance MonadJSM (UnrunnableT js t m) where
-  liftJSM' _ = UnrunnableT $ \case
+  liftJSM' _ = unrunnable
 instance Reflex t => PostBuild t (UnrunnableT js t m)
 instance PrimMonad (UnrunnableT js t m) where
 --  type RawDocument (UnrunnableT js t m) = DOM.Document
 --instance HasJSContext (UnrunnableT js t m)
 --instance MonadJSM (UnrunnableT js t m)
 instance Reflex t => DomRenderHook t (UnrunnableT js t m) where
-  withRenderHook _ _ = UnrunnableT $ \case
-  requestDomAction _ = UnrunnableT $ \case
-  requestDomAction_ _ = UnrunnableT $ \case
+  withRenderHook _ _ = unrunnable
+  requestDomAction _ = unrunnable
+  requestDomAction_ _ = unrunnable
 instance Reflex t => Prerender JS' t (UnrunnableT js t m) where
   type Client (UnrunnableT js t m) = UnrunnableT js t m
-  prerender _ _ = UnrunnableT $ \case
+  prerender _ _ = unrunnable
 
 instance (SupportsStaticDomBuilder t m) => Prerender JS' t (StaticDomBuilderT t m) where
   type Client (StaticDomBuilderT t m) = UnrunnableT JS' t m

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -39,7 +39,6 @@ import Reflex.Dom.Builder.Immediate
 import Reflex.Dom.Builder.InputDisabled
 import Reflex.Dom.Builder.Static
 import Reflex.Host.Class
-import Reflex.Requester.Base
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE EmptyCase #-}
-{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -137,7 +136,7 @@ newtype UnrunnableT js t m a = UnrunnableT (ReaderT Void m a)
   deriving (Functor, Applicative, Monad, MonadTrans)
 
 unrunnable :: UnrunnableT js t m a
-unrunnable = UnrunnableT $ ReaderT $ \case
+unrunnable = UnrunnableT $ ReaderT $ \case {}
 
 instance (Reflex t, Monad m) => DomBuilder t (UnrunnableT js t m) where
   type DomBuilderSpace (UnrunnableT js t m) = GhcjsDomSpace

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -83,7 +83,7 @@ prerender_
   => m () ->  Client m () -> m ()
 prerender_ server client = void $ prerender server client
 
-class (PrerenderClientConstraint js t (Client m), Client (Client m) ~ Client m, Prerender js t m) => Prerender js t m | m -> t js where
+class (PrerenderClientConstraint js t (Client m), Client (Client m) ~ Client m, Prerender js t (Client m)) => Prerender js t m | m -> t js where
   -- | Monad in which the client widget is built
   type Client m :: * -> *
   -- | Render the first widget on the server, and the second on the client. The


### PR DESCRIPTION
That way we never need lie about what constraints we have in an (function) argument to make it uncallable.

TODO test rebase builds, and test result