### PR TITLE
Expose TextNode's update event

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -182,8 +182,9 @@ instance (Reflex t) => Default (TextNodeConfig t) where
     , _textNodeConfig_setContents = Nothing
     }
 
-newtype TextNode d t = TextNode
+data TextNode d t = TextNode
   { _textNode_raw :: RawTextNode d
+  , _textNode_contentsUpdated :: Event t Text
   }
 
 data CommentNodeConfig t

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -268,7 +268,7 @@ instance SupportsStaticDomBuilder t m => DomBuilder t (StaticDomBuilderT t m) wh
     modify . (:) =<< case mSetContents of
       Nothing -> return (pure (escape initialContents))
       Just setContents -> hold (escape initialContents) $ fmapCheap escape setContents --Only because it doesn't get optimized when profiling is on
-    return $ TextNode ()
+    return $ TextNode () never
   {-# INLINABLE commentNode #-}
   commentNode (CommentNodeConfig initialContents mSetContents) = StaticDomBuilderT $ do
     --TODO: Do not escape quotation marks; see https://stackoverflow.com/questions/25612166/what-characters-must-be-escaped-in-html-5

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -14,6 +14,7 @@ module Reflex.Dom.Widget.Basic
   -- * Displaying Values
     text
   , dynText
+  , dynText'
   , comment
   , dynComment
   , display
@@ -111,15 +112,20 @@ partitionMapBySetLT s m0 = Map.fromDistinctAscList $ go (Set.toAscList s) m0
 text :: DomBuilder t m => Text -> m ()
 text t = void $ textNode $ def & textNodeConfig_initialContents .~ t
 
-{-# INLINABLE dynText #-}
-dynText :: forall t m. (PostBuild t m, DomBuilder t m) => Dynamic t Text -> m ()
-dynText t = do
+{-# INLINABLE dynText' #-}
+dynText' :: forall t m. (PostBuild t m, DomBuilder t m) => Dynamic t Text -> m (TextNode (DomBuilderSpace m) t)
+dynText' t = do
   postBuild <- getPostBuild
-  void $ textNode $ (def :: TextNodeConfig t) & textNodeConfig_setContents .~ leftmost
+  tn <- textNode $ (def :: TextNodeConfig t) & textNodeConfig_setContents .~ leftmost
     [ updated t
     , tag (current t) postBuild
     ]
   notReadyUntil postBuild
+  return tn
+
+{-# INLINABLE dynText #-}
+dynText :: forall t m. (PostBuild t m, DomBuilder t m) => Dynamic t Text -> m ()
+dynText = void . dynText'
 
 comment :: DomBuilder t m => Text -> m ()
 comment t = void $ commentNode $ def & commentNodeConfig_initialContents .~ t


### PR DESCRIPTION
This PR exposes event that fires right after TextNode contents has been updated. This event is usefull when you want to access the underlying text node's metric, like length/char positions/etc. 