### PR TITLE
Hydration fixes

### DIFF
--- a/reflex-dom-core/ChangeLog.md
+++ b/reflex-dom-core/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for reflex-dom-core
 
+## Unreleased
+
+* Added support for marking elements with a "data-skip-hydration" attribute, which will cause hydration to ignore and skip over them.
+* Removed "data-ssr" attributes from statically rendered output.:q
+
 ## 0.5
 
 * Add HydrationDomBuilderT to support hydration of statically rendered DOM nodes. See the note at the top of Reflex.Dom.Builder.Immediate.

--- a/reflex-dom-core/ChangeLog.md
+++ b/reflex-dom-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for reflex-dom-core
 
+## 0.5.2
+
+* Update to use new dependent-sum/map packages and drop dependency on `*Tag` classes (e.g., `ShowTag`).
+
 ## 0.5.1
 
 * Added support for marking elements with a "data-skip-hydration" attribute, which will cause hydration to ignore and skip over them.

--- a/reflex-dom-core/ChangeLog.md
+++ b/reflex-dom-core/ChangeLog.md
@@ -1,6 +1,6 @@
 # Revision history for reflex-dom-core
 
-## Unreleased
+## 0.5.1
 
 * Added support for marking elements with a "data-skip-hydration" attribute, which will cause hydration to ignore and skip over them.
 * Removed "data-ssr" attributes from statically rendered output.:q

--- a/reflex-dom-core/default.nix
+++ b/reflex-dom-core/default.nix
@@ -25,7 +25,7 @@ let addGcTestDepends = drv: if (stdenv.system != "x86_64-linux" || stdenv.hostPl
     };
 in mkDerivation (addGcTestDepends {
   pname = "reflex-dom-core";
-  version = "0.5";
+  version = "0.5.1";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bifunctors bimap blaze-builder bytestring constraints

--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -1,5 +1,5 @@
 Name: reflex-dom-core
-Version: 0.5
+Version: 0.5.1
 Synopsis: Functional Reactive Web Apps with Reflex
 Description: Reflex-DOM is a Functional Reactive web framework based on the Reflex FRP engine
 License: BSD3
@@ -53,7 +53,7 @@ library
     contravariant >= 1.4 && < 1.6,
     data-default >= 0.5 && < 0.8,
     dependent-map >= 0.2 && < 0.4,
-    dependent-sum >= 0.3 && < 0.7,
+    dependent-sum >= 0.5 && < 0.7,
     dependent-sum-template >= 0.0.0.4 && < 0.2,
     directory >= 1.2 && < 1.4,
     exception-transformers == 0.4.*,
@@ -133,7 +133,7 @@ library
 
   if flag(use-template-haskell)
     build-depends:
-      dependent-sum >= 0.3 && < 0.7,
+      dependent-sum >= 0.5,
       dependent-sum-template >= 0.0.0.5 && < 0.2,
       template-haskell
     other-extensions: TemplateHaskell
@@ -142,7 +142,7 @@ library
       Reflex.Dom.Builder.Class.TH
   else
     build-depends:
-      dependent-sum == 0.4.*
+      dependent-sum == 0.5
 
 test-suite hlint
   build-depends: base, hlint

--- a/reflex-dom-core/test/hydration.hs
+++ b/reflex-dom-core/test/hydration.hs
@@ -1399,7 +1399,28 @@ data Key2 a where
   Key2_Int :: Int -> Key2 Int
   Key2_Char :: Char -> Key2 Char
 
+
+instance ShowTag DKey Identity where
+  showTaggedPrec = \case
+    Key_Int -> showsPrec
+    Key_Char -> showsPrec
+    Key_Bool -> showsPrec
+
+instance EqTag DKey Identity where
+  eqTagged Key_Int Key_Int = (==)
+  eqTagged Key_Char Key_Char = (==)
+  eqTagged Key_Bool Key_Bool = (==)
+
 deriveGEq ''Key2
 deriveGCompare ''Key2
 deriveGShow ''Key2
 deriveArgDict ''Key2
+
+instance ShowTag Key2 Identity where
+  showTaggedPrec = \case
+    Key2_Int _ -> showsPrec
+    Key2_Char _ -> showsPrec
+
+instance EqTag Key2 Identity where
+  eqTagged (Key2_Int _) (Key2_Int _) = (==)
+  eqTagged (Key2_Char _) (Key2_Char _) = (==)

--- a/reflex-dom-core/test/hydration.hs
+++ b/reflex-dom-core/test/hydration.hs
@@ -280,13 +280,6 @@ tests withDebugging wdConfig caps _selenium = do
         (e, ()) <- element "div" conf $ text "hello world"
         let click = domEvent Click e
         return ()
-    -- TODO check this is the correct solution
-    it "has ssr attribute, removes ssr attribute" $ runWD $ do
-      let checkSSRAttr = do
-            e <- findElemWithRetry $ WD.ByTag "div"
-            assertAttr e "data-ssr" (Just "")
-            pure e
-      testWidget' checkSSRAttr (\e -> assertAttr e "data-ssr" Nothing) $ el "div" $ text "hello world"
 
   describe "inputElement" $ do
     describe "hydration" $ session' $ do

--- a/reflex-dom/ChangeLog.md
+++ b/reflex-dom/ChangeLog.md
@@ -1,5 +1,7 @@
 # Revision history for reflex-dom
 
+## 0.5.1
+
 * The default jsaddle backend on macOS when built from nix
   is now jsaddle-wkwebview, matching the behaviour of cabal
   builds.

--- a/reflex-dom/default.nix
+++ b/reflex-dom/default.nix
@@ -11,7 +11,7 @@ let isAndroid = hostPlatform.libc == "bionic";
     }.${ghcBackend};
 in mkDerivation {
   pname = "reflex-dom";
-  version = "0.5";
+  version = "0.5.1";
   src = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) [ ".git" "dist" ])) ./.;
   libraryHaskellDepends = [
     base bytestring reflex reflex-dom-core text

--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -68,7 +68,7 @@ library
     reflex-dom-core >=0.5 && <0.6,
     text == 1.2.*
   if !impl(ghcjs)
-    if flag(use-warp)
+    if flag(use-warp) && (os(linux) || os(osx))
       build-depends:
         jsaddle,
         jsaddle-warp

--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -1,5 +1,5 @@
 Name: reflex-dom
-Version: 0.5
+Version: 0.5.1
 Synopsis: Functional Reactive Web Apps with Reflex
 Description:
   Reflex-DOM is a Functional Reactive web framework based on the Reflex FRP engine.


### PR DESCRIPTION
In an attempt to fix hydration in the presence of executable-config, we add the option of marking tags with a "data-hydration-skip" attribute, and remove the "data-ssr" attribute from static rendering. Prior to this, tags without the "data-ssr" attribute would be skipped over by hydration, now that only occurs for tags with "data-hydration-skip", and everything else is matched. (We're still not yet checking to ensure attributes are equal.)

This seems to fix the interaction alongside the PR I'm about to make on Obelisk.