### PR TITLE
Skip hydration for elements with data-ssr attribute

### DIFF
--- a/reflex-dom-core/ChangeLog.md
+++ b/reflex-dom-core/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for reflex-dom-core
 
+## Unreleased
+
+* Reintroduce "data-ssr": elements without this attribute are skipped during
+  hydration.
+
 ## 0.5.2
 
 * Update to use new dependent-sum/map packages and drop dependency on `*Tag` classes (e.g., `ShowTag`).

--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -95,6 +95,7 @@ library
     Reflex.Dom.Builder.Class.Events
     Reflex.Dom.Builder.Immediate
     Reflex.Dom.Builder.InputDisabled
+    Reflex.Dom.Builder.Hydratable
     Reflex.Dom.Builder.Static
     Reflex.Dom.Class
     Reflex.Dom.Core

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Hydratable.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Hydratable.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Reflex.Dom.Builder.Hydratable where
+
+import Control.Monad.Fix
+import Control.Monad.Primitive
+import Control.Monad.Ref
+import Control.Monad.Trans
+import Control.Monad.Trans.Control
+import Data.Coerce
+import qualified Data.Map as Map
+import Foreign.JavaScript.TH
+#ifndef ghcjs_HOST_OS
+import GHCJS.DOM.Types (MonadJSM (..))
+#endif
+import Reflex
+import Reflex.Dom.Builder.Class
+import Reflex.Dom.Builder.Immediate (HasDocument (..))
+import Reflex.Host.Class
+
+-- | A DomBuilder transformer that adds "data-ssr" to all elements such that the
+-- hydration builder knows which bits of DOM were added by us, and which were
+-- added by external scripts.
+newtype HydratableT m a = HydratableT { runHydratableT :: m a } deriving (Functor, Applicative, Monad, MonadAtomicRef, MonadFix, MonadIO)
+
+#ifndef ghcjs_HOST_OS
+instance MonadJSM m => MonadJSM (HydratableT m) where
+    liftJSM' = HydratableT . liftJSM'
+#endif
+
+deriving instance MonadSample t m => MonadSample t (HydratableT m)
+deriving instance MonadHold t m => MonadHold t (HydratableT m)
+
+instance MonadTrans HydratableT where
+  lift = HydratableT
+
+instance MonadTransControl HydratableT where
+  type StT HydratableT a = a
+  liftWith f = HydratableT $ f runHydratableT
+  restoreT = HydratableT
+
+instance MonadRef m => MonadRef (HydratableT m) where
+  type Ref (HydratableT m) = Ref m
+  newRef = lift . newRef
+  readRef = lift . readRef
+  writeRef ref = lift . writeRef ref
+
+instance PerformEvent t m => PerformEvent t (HydratableT m) where
+  type Performable (HydratableT m) = Performable m
+  performEvent_ = lift . performEvent_
+  performEvent = lift . performEvent
+
+instance PrimMonad m => PrimMonad (HydratableT m) where
+  type PrimState (HydratableT m) = PrimState m
+  primitive = lift . primitive
+
+makeHydratable :: Reflex t => ElementConfig er t m -> ElementConfig er t m
+makeHydratable cfg = cfg
+  { _elementConfig_initialAttributes = Map.insert "data-ssr" "" $ _elementConfig_initialAttributes cfg
+  , _elementConfig_modifyAttributes = fmap (Map.delete "data-ssr") <$> _elementConfig_modifyAttributes cfg
+  }
+
+instance PostBuild t m => PostBuild t (HydratableT m) where
+  getPostBuild = lift getPostBuild
+
+deriving instance TriggerEvent t m => TriggerEvent t (HydratableT m)
+
+instance MonadReflexCreateTrigger t m => MonadReflexCreateTrigger t (HydratableT m) where
+  newEventWithTrigger = lift . newEventWithTrigger
+  newFanEventWithTrigger f = lift $ newFanEventWithTrigger f
+
+instance Adjustable t m => Adjustable t (HydratableT m) where
+  runWithReplace a0 a' = HydratableT $ runWithReplace (coerce a0) (coerceEvent a')
+  traverseDMapWithKeyWithAdjust f dm0 dm' = HydratableT $ traverseDMapWithKeyWithAdjust (\k v -> runHydratableT $ f k v) (coerce dm0) (coerceEvent dm')
+  traverseDMapWithKeyWithAdjustWithMove f dm0 dm' = HydratableT $ traverseDMapWithKeyWithAdjustWithMove (\k v -> runHydratableT $ f k v) (coerce dm0) (coerceEvent dm')
+  traverseIntMapWithKeyWithAdjust f m0 m' = HydratableT $ traverseIntMapWithKeyWithAdjust (\k v -> runHydratableT $ f k v) (coerce m0) (coerceEvent m')
+
+instance NotReady t m => NotReady t (HydratableT m) where
+  notReadyUntil = lift . notReadyUntil
+  notReady = lift notReady
+
+instance DomBuilder t m => DomBuilder t (HydratableT m) where
+  type DomBuilderSpace (HydratableT m) = DomBuilderSpace m
+  element t cfg = lift . element t (makeHydratable cfg) . runHydratableT
+  inputElement cfg = lift $ inputElement $ cfg
+    { _inputElementConfig_elementConfig = makeHydratable $ _inputElementConfig_elementConfig cfg
+    }
+  textAreaElement cfg = lift $ textAreaElement $ cfg
+    { _textAreaElementConfig_elementConfig = makeHydratable $ _textAreaElementConfig_elementConfig cfg
+    }
+  selectElement cfg child = do
+    let cfg' = cfg
+          { _selectElementConfig_elementConfig = makeHydratable $ _selectElementConfig_elementConfig cfg
+          }
+    lift $ selectElement cfg' $ runHydratableT child
+
+instance HasDocument m => HasDocument (HydratableT m)
+
+instance HasJSContext m => HasJSContext (HydratableT m) where
+  type JSContextPhantom (HydratableT m) = JSContextPhantom m
+  askJSContext = lift askJSContext
+
+instance HasJS js m => HasJS js (HydratableT m) where
+  type JSX (HydratableT m) = JSX m
+  liftJS = lift . liftJS
+
+instance DomRenderHook t m => DomRenderHook t (HydratableT m) where
+  withRenderHook f = HydratableT . withRenderHook f . runHydratableT
+  requestDomAction = HydratableT . requestDomAction
+  requestDomAction_ = HydratableT . requestDomAction_

--- a/reflex-dom-core/src/Reflex/Dom/Builder/InputDisabled.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/InputDisabled.hs
@@ -80,6 +80,7 @@ instance Adjustable t m => Adjustable t (InputDisabledT m) where
   runWithReplace a0 a' = InputDisabledT $ runWithReplace (coerce a0) (coerceEvent a')
   traverseDMapWithKeyWithAdjust f dm0 dm' = InputDisabledT $ traverseDMapWithKeyWithAdjust (\k v -> runInputDisabledT $ f k v) (coerce dm0) (coerceEvent dm')
   traverseDMapWithKeyWithAdjustWithMove f dm0 dm' = InputDisabledT $ traverseDMapWithKeyWithAdjustWithMove (\k v -> runInputDisabledT $ f k v) (coerce dm0) (coerceEvent dm')
+  traverseIntMapWithKeyWithAdjust f m0 m' = InputDisabledT $ traverseIntMapWithKeyWithAdjust (\k v -> runInputDisabledT $ f k v) (coerce m0) (coerceEvent m')
 
 instance NotReady t m => NotReady t (InputDisabledT m) where
   notReadyUntil = lift . notReadyUntil
@@ -108,3 +109,8 @@ instance HasJSContext m => HasJSContext (InputDisabledT m) where
 instance HasJS js m => HasJS js (InputDisabledT m) where
   type JSX (InputDisabledT m) = JSX m
   liftJS = lift . liftJS
+
+instance DomRenderHook t m => DomRenderHook t (InputDisabledT m) where
+  withRenderHook f = InputDisabledT . withRenderHook f . runInputDisabledT
+  requestDomAction = InputDisabledT . requestDomAction
+  requestDomAction_ = InputDisabledT . requestDomAction_

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -288,7 +288,7 @@ instance SupportsStaticDomBuilder t m => DomBuilder t (StaticDomBuilderT t m) wh
     StaticDomBuilderT $ do
       let shouldEscape = elementTag `Set.notMember` noEscapeElements
       (result, innerHtml) <- lift $ lift $ runStaticDomBuilderT child $ StaticDomBuilderEnv shouldEscape Nothing
-      attrs0 <- foldDyn applyMap (Map.insert "data-ssr" "" $ cfg ^. initialAttributes) (cfg ^. modifyAttributes)
+      attrs0 <- foldDyn applyMap (cfg ^. initialAttributes) (cfg ^. modifyAttributes)
       selectValue <- asks _staticDomBuilderEnv_selectValue
       let addSelectedAttr attrs sel = case Map.lookup "value" attrs of
             Just v | v == sel -> attrs <> Map.singleton "selected" ""

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -288,7 +288,7 @@ instance SupportsStaticDomBuilder t m => DomBuilder t (StaticDomBuilderT t m) wh
     StaticDomBuilderT $ do
       let shouldEscape = elementTag `Set.notMember` noEscapeElements
       (result, innerHtml) <- lift $ lift $ runStaticDomBuilderT child $ StaticDomBuilderEnv shouldEscape Nothing
-      attrs0 <- foldDyn applyMap (cfg ^. initialAttributes) (cfg ^. modifyAttributes)
+      attrs0 <- foldDyn applyMap (Map.insert "data-ssr" "" $ cfg ^. initialAttributes) (cfg ^. modifyAttributes)
       selectValue <- asks _staticDomBuilderEnv_selectValue
       let addSelectedAttr attrs sel = case Map.lookup "value" attrs of
             Just v | v == sel -> attrs <> Map.singleton "selected" ""

--- a/reflex-dom-core/src/Reflex/Dom/Core.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Core.hs
@@ -6,6 +6,7 @@ module Reflex.Dom.Core (module X) where
 
 import Reflex as X hiding (askEvents)
 import Reflex.Dom.Builder.Class as X
+import Reflex.Dom.Builder.Hydratable as X
 import Reflex.Dom.Builder.Immediate as X
 import Reflex.Dom.Builder.InputDisabled as X
 import Reflex.Dom.Builder.Static as X

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -33,6 +33,7 @@ import Foreign.JavaScript.TH
 import GHCJS.DOM.Types (MonadJSM)
 import Reflex hiding (askEvents)
 import Reflex.Dom.Builder.Class
+import Reflex.Dom.Builder.Hydratable
 import Reflex.Dom.Builder.Immediate
 import Reflex.Dom.Builder.InputDisabled
 import Reflex.Dom.Builder.Static
@@ -283,8 +284,12 @@ instance (Prerender js t m, Monad m, Reflex t, MonadFix m, Group q, Additive q, 
     pure a
 
 instance (Prerender js t m, Monad m) => Prerender js t (InputDisabledT m) where
-  type Client (InputDisabledT m) = Client m
-  prerender (InputDisabledT server) client = InputDisabledT $ prerender server client
+  type Client (InputDisabledT m) = InputDisabledT (Client m)
+  prerender (InputDisabledT server) (InputDisabledT client) = InputDisabledT $ prerender server client
+
+instance (Prerender js t m, Monad m) => Prerender js t (HydratableT m) where
+  type Client (HydratableT m) = HydratableT (Client m)
+  prerender (HydratableT server) (HydratableT client) = HydratableT $ prerender server client
 
 instance (Prerender js t m, Monad m, ReflexHost t) => Prerender js t (PostBuildT t m) where
   type Client (PostBuildT t m) = PostBuildT t (Client m)

--- a/reflex-dom-core/test/hydration.hs
+++ b/reflex-dom-core/test/hydration.hs
@@ -1347,7 +1347,7 @@ testWidgetDebug' withDebugging beforeJS afterSwitchover bodyWidget = do
           bodyWidget
           el "script" $ text $ TE.decodeUtf8 $ LBS.toStrict $ jsaddleJs False
   putStrLnDebug "rendering static"
-  ((), html) <- liftIO $ renderStatic staticApp
+  ((), html) <- liftIO $ renderStatic $ runHydratableT staticApp
   putStrLnDebug "rendered static"
   waitBeforeJS <- liftIO newEmptyMVar -- Empty until JS should be run
   waitUntilSwitchover <- liftIO newEmptyMVar -- Empty until switchover


### PR DESCRIPTION
https://github.com/reflex-frp/reflex-dom/pull/317/commits/9bd809bc00f88834f23b427e3d2adc0cb0fb09b1 removed data-ssr in favour of explicitly skipping certain elements. Allowing explicit skipping is a good change, but the lack of implicitly skipping things which _aren't_  produced by the static renderer causes somewhat unsolvable issues when using certain external JS libraries, for example, the ace editor, which injects some `style` tags into the head. This PR supports both explicit and implicit skipping of elements during hydration.