### PR TITLE
Bump reflex-platform for tests

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -2,6 +2,6 @@
   "owner": "reflex-frp",
   "repo": "reflex-platform",
   "branch": "develop",
-  "rev": "e637442042c6e6f6914314b5c2d3a19edf48d31f",
-  "sha256": "0aajnvx83r26r22n1sr0imhzh073wfsf85hbshsxd95l47jw6i7c"
+  "rev": "8f4b8973a06f78c7aaf1a222f8f8443cd934569f",
+  "sha256": "167smg7dyvg5yf1wn9bx6yxvazlk0qk64rzgm2kfzn9mx873s0vp"
 }


### PR DESCRIPTION
This improves cabal2nix for mobile, and is needed for https://github.com/reflex-frp/reflex-dom/pull/329