### PR TITLE
Loosen constraints version bounds for reflex-dom-core.

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -49,7 +49,7 @@ library
     blaze-builder,
     bytestring == 0.10.*,
     containers >= 0.5 && < 0.7,
-    constraints >= 0.9 && < 0.11,
+    constraints >= 0.9 && < 0.12,
     contravariant >= 1.4 && < 1.6,
     data-default >= 0.5 && < 0.8,
     dependent-map >= 0.3 && < 0.4,


### PR DESCRIPTION
This does not introduce anything that actually _uses_ the new features of `constraints-0.11.*` as it only changes the version bounds in the Cabal file. Compiling `reflex-dom-core` with the new version did not appear to introduce any build-time warnings or errors. The `constraints-extras` package (which has Obsidian maintainers) has also made this same change without any apparent issues and therefore I believe it is reasonably safe.