### PR TITLE
WIP: Show call stack of a node in DOM comments

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -60,6 +60,7 @@ import Data.Semigroup
 import Data.String
 import Data.Text (Text)
 import Data.Type.Coercion
+import GHC.Stack
 import GHCJS.DOM.Types (JSM)
 import qualified GHCJS.DOM.Types as DOM
 
@@ -96,8 +97,9 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
                    => CommentNodeConfig t -> m (CommentNode (DomBuilderSpace m) t)
   commentNode = lift . commentNode
   {-# INLINABLE commentNode #-}
-  element :: Text -> ElementConfig er t (DomBuilderSpace m) -> m a -> m (Element er (DomBuilderSpace m) t, a)
-  default element :: ( MonadTransControl f
+  element :: HasCallStack => Text -> ElementConfig er t (DomBuilderSpace m) -> m a -> m (Element er (DomBuilderSpace m) t, a)
+  default element :: ( HasCallStack
+                     , MonadTransControl f
                      , StT f a ~ a
                      , m ~ f m'
                      , DomBuilderSpace m' ~ DomBuilderSpace m

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -90,6 +90,7 @@ import Data.These
 import Data.Traversable
 import Prelude hiding (mapM, mapM_, sequence, sequence_)
 
+import GHC.Stack
 -- | Breaks the given Map into pieces based on the given Set.  Each piece will contain only keys that are less than the key of the piece, and greater than or equal to the key of the piece with the next-smaller key.  There will be one additional piece containing all keys from the original Map that are larger or equal to the largest key in the Set.
 -- Either k () is used instead of Maybe k so that the resulting map of pieces is sorted so that the additional piece has the largest key.
 -- No empty pieces will be included in the output.
@@ -172,7 +173,7 @@ widgetHold_ z = void . widgetHold z
 -- >>> el "div" (text "Hello World")
 -- <div>Hello World</div>
 {-# INLINABLE el #-}
-el :: forall t m a. DomBuilder t m => Text -> m a -> m a
+el :: forall t m a. (HasCallStack, DomBuilder t m) => DomBuilder t m => Text -> m a -> m a
 el elementTag child = snd <$> el' elementTag child
 
 -- | Create a DOM element with attributes
@@ -180,7 +181,7 @@ el elementTag child = snd <$> el' elementTag child
 -- >>> elAttr "a" ("href" =: "https://reflex-frp.org") (text "Reflex-FRP!")
 -- <a href="https://reflex-frp.org">Reflex-FRP!</a>
 {-# INLINABLE elAttr #-}
-elAttr :: forall t m a. DomBuilder t m => Text -> Map Text Text -> m a -> m a
+elAttr :: forall t m a. (HasCallStack, DomBuilder t m) => Text -> Map Text Text -> m a -> m a
 elAttr elementTag attrs child = snd <$> elAttr' elementTag attrs child
 
 -- | Create a DOM element with classes
@@ -188,7 +189,7 @@ elAttr elementTag attrs child = snd <$> elAttr' elementTag attrs child
 -- >>> elClass "div" "row" (return ())
 -- <div class="row"></div>
 {-# INLINABLE elClass #-}
-elClass :: forall t m a. DomBuilder t m => Text -> Text -> m a -> m a
+elClass :: forall t m a. (HasCallStack, DomBuilder t m) => Text -> Text -> m a -> m a
 elClass elementTag c child = snd <$> elClass' elementTag c child
 
 -- | Create a DOM element with Dynamic Attributes
@@ -196,7 +197,7 @@ elClass elementTag c child = snd <$> elClass' elementTag c child
 -- >>> elClass "div" (constDyn ("class" =: "row")) (return ())
 -- <div class="row"></div>
 {-# INLINABLE elDynAttr #-}
-elDynAttr :: forall t m a. (DomBuilder t m, PostBuild t m) => Text -> Dynamic t (Map Text Text) -> m a -> m a
+elDynAttr :: forall t m a. (HasCallStack, DomBuilder t m, PostBuild t m) => Text -> Dynamic t (Map Text Text) -> m a -> m a
 elDynAttr elementTag attrs child = snd <$> elDynAttr' elementTag attrs child
 
 -- | Create a DOM element with a Dynamic Class
@@ -204,7 +205,7 @@ elDynAttr elementTag attrs child = snd <$> elDynAttr' elementTag attrs child
 -- >>> elDynClass "div" (constDyn "row") (return ())
 -- <div class="row"></div>
 {-# INLINABLE elDynClass #-}
-elDynClass :: forall t m a. (DomBuilder t m, PostBuild t m) => Text -> Dynamic t Text -> m a -> m a
+elDynClass :: forall t m a. (HasCallStack, DomBuilder t m, PostBuild t m) => Text -> Dynamic t Text -> m a -> m a
 elDynClass elementTag c child = snd <$> elDynClass' elementTag c child
 
 -- | Create a DOM element and return the element
@@ -214,32 +215,32 @@ elDynClass elementTag c child = snd <$> elDynClass' elementTag c child
 --     return $ domEvent Click e
 -- @
 {-# INLINABLE el' #-}
-el' :: forall t m a. DomBuilder t m => Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
+el' :: forall t m a. (HasCallStack, DomBuilder t m) => Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 el' elementTag = element elementTag def
 
 -- | Create a DOM element with attributes and return the element
 {-# INLINABLE elAttr' #-}
-elAttr' :: forall t m a. DomBuilder t m => Text -> Map Text Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
+elAttr' :: forall t m a. (HasCallStack, DomBuilder t m) => Text -> Map Text Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 elAttr' elementTag attrs = element elementTag $ def
   & initialAttributes .~ Map.mapKeys (AttributeName Nothing) attrs
 
 -- | Create a DOM element with a class and return the element
 {-# INLINABLE elClass' #-}
-elClass' :: forall t m a. DomBuilder t m => Text -> Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
+elClass' :: forall t m a. (HasCallStack, DomBuilder t m) => Text -> Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 elClass' elementTag c = elAttr' elementTag ("class" =: c)
 
 -- | Create a DOM element with Dynamic Attributes and return the element
 {-# INLINABLE elDynAttr' #-}
-elDynAttr' :: forall t m a. (DomBuilder t m, PostBuild t m) => Text -> Dynamic t (Map Text Text) -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
+elDynAttr' :: forall t m a. (HasCallStack, DomBuilder t m, PostBuild t m) => Text -> Dynamic t (Map Text Text) -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 elDynAttr' = elDynAttrNS' Nothing
 
 -- | Create a DOM element with a Dynamic class and return the element
 {-# INLINABLE elDynClass' #-}
-elDynClass' :: forall t m a. (DomBuilder t m, PostBuild t m) => Text -> Dynamic t Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
+elDynClass' :: forall t m a. (HasCallStack, DomBuilder t m, PostBuild t m) => Text -> Dynamic t Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 elDynClass' elementTag c = elDynAttr' elementTag (fmap ("class" =:) c)
 
 {-# INLINABLE elDynAttrNS' #-}
-elDynAttrNS' :: forall t m a. (DomBuilder t m, PostBuild t m) => Maybe Text -> Text -> Dynamic t (Map Text Text) -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
+elDynAttrNS' :: forall t m a. (HasCallStack, DomBuilder t m, PostBuild t m) => Maybe Text -> Text -> Dynamic t (Map Text Text) -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 elDynAttrNS' mns elementTag attrs child = do
   modifyAttrs <- dynamicAttributesToModifyAttributes attrs
   let cfg = def
@@ -251,7 +252,7 @@ elDynAttrNS' mns elementTag attrs child = do
   return result
 
 {-# INLINABLE elDynAttrNS #-}
-elDynAttrNS :: forall t m a. (DomBuilder t m, PostBuild t m) => Maybe Text -> Text -> Dynamic t (Map Text Text) -> m a -> m a
+elDynAttrNS :: forall t m a. (HasCallStack, DomBuilder t m, PostBuild t m) => Maybe Text -> Text -> Dynamic t (Map Text Text) -> m a -> m a
 elDynAttrNS mns elementTag attrs child = fmap snd $ elDynAttrNS' mns elementTag attrs child
 
 dynamicAttributesToModifyAttributes :: (Ord k, PostBuild t m) => Dynamic t (Map k Text) -> m (Event t (Map k (Maybe Text)))
@@ -287,7 +288,7 @@ linkClass s c = do
 link :: DomBuilder t m => Text -> m (Link t)
 link s = linkClass s ""
 
-divClass :: forall t m a. DomBuilder t m => Text -> m a -> m a
+divClass :: forall t m a. (HasCallStack, DomBuilder t m) => Text -> m a -> m a
 divClass = elClass "div"
 
 {-# DEPRECATED dtdd "Use an application specific widget generating function" #-}


### PR DESCRIPTION
When ran on the `obelisk` skeleton:
![node-callstack](https://user-images.githubusercontent.com/2335822/71774374-3b38c500-2f65-11ea-9120-4f9899063e55.png)

It would be convenient being able to know what place in the codebase a widget is coming from. The idea here being that one can directly right-click it, choose 'Inspect element' and read the comment immediately before the node. That said, this brings several annoying concerns to the table.

#### Security
It sounds like a very bad idea to allow easily deploying closed source code which leaks this much info about itself. I was planning to gate this behavior based on whether `--interactive` was being passed to ghc, but there seems to be no way to detect that with CPP? Maybe we could add a cabal flag for this purpose that would both force `--interactive` and add a CPP flag to gate on instead? I don't know how this sort of configuration is usually handled.

#### Scope
> place in the codebase a widget is coming from

 is very fuzzy given all the factoring, (re)composing and delegating that happens - I see things divided in

1. the point where `element` and the `el` family of functions are called
1. framework/middleware/lib in between your call in __1__ and `reflex-dom` (e.g. the `DomBuilder` chain coming from `obelisk` in the screenshot)
1. the call stack of your own app/lib that leads down to __1__

I think it should mean at least __1__ since this is the usual way of telling `reflex-dom` to create nodes (hence where the execution "leaves" your code), but depending on use case one might want to include __2__ and/or __3__. 

From a quick look, it seems __3__ can be "turned on globally" in an application by adding `CallStack` to the typical all-the-app-wide-constraints synonym (`AppWidget` or something similar).

@tomsmalley suggested adding a transformer for controlling this behavior, which would make it easy to control scope, e.g.
- adding "runTransformer" at some desired scope
- supplying some configuration to the transformer - examples: keeping only __1__, filtering out `obelisk`, filtering out `lift`ed `element` entries coming from `reflex-dom` (see [`removeSelf`](https://github.com/reflex-frp/reflex-dom/pull/354/files#diff-d754f8d955d20a2fcf6488778a2155e0R265)) 

#### Performance
I'm assuming this will never ever *ever* __*ever*__ run outside `ghci`, where we can quickly toggle it off if in the unlikely case it turns out to have a remotely noticeable effect at some point.