### PR TITLE
Avoid runWithReplace call when hydrating

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
@@ -318,8 +318,7 @@ addHydrationStepWithSetup :: (Adjustable t m, MonadIO m) => m a -> (a -> Hydrati
 addHydrationStepWithSetup setup f = getHydrationMode >>= \case
   HydrationMode_Immediate -> pure ()
   HydrationMode_Hydrating -> do
-    switchover <- HydrationDomBuilderT $ asks _hydrationDomBuilderEnv_switchover
-    (s, _) <- lift $ runWithReplace setup $ return () <$ switchover
+    s <- lift setup
     addHydrationStep (f s)
 
 -- | Add a hydration step


### PR DESCRIPTION
This simplifies things, and avoids creating extra events.

/cc @tomsmalley @ryantrinkle
