### PR TITLE
Remove deprecation warnings for Reflex.Dom.Widget.Basic

### DIFF
--- a/reflex-dom-core/ChangeLog.md
+++ b/reflex-dom-core/ChangeLog.md
@@ -1,5 +1,18 @@
 # Revision history for reflex-dom-core
 
+## Unreleased
+
+* Remove deprecation warnings for the following widgets in
+  `Reflex.Dom.Widget.Basic`:
+
+   * `Link`
+   * `button`
+   * `dtdd`
+   * `linkClass`
+   * `link`
+   * `tabDisplay`
+   * `tableDynAttr`
+
 ## 0.5.3
 
 * Deprecate a number of old inflexible widget helpers in `Reflex.Dom.Widget.Basic`:

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -138,7 +138,6 @@ dynComment t = do
 display :: (PostBuild t m, DomBuilder t m, Show a) => Dynamic t a -> m ()
 display = dynText . fmap (T.pack . show)
 
-{-# DEPRECATED button "Use 'elAttr'' in combination with 'domEvent' instead" #-}
 button :: DomBuilder t m => Text -> m (Event t ())
 button t = do
   (e, _) <- element "button" def $ text t
@@ -272,25 +271,21 @@ dynamicAttributesToModifyAttributesWithInitial attrs0 d = do
         return $ if Map.null p then Nothing else Just p
   return modificationsNeeded
 
-{-# DEPRECATED Link "Will be removed when 'linkClass' and 'link' are removed. Follow those functions' deprecation instructions." #-}
 newtype Link t
   = Link { _link_clicked :: Event t ()
          }
 
-{-# DEPRECATED linkClass "Use 'elAttr'' in combination with 'domEvent' for just clicks. Use 'routeLink' for Obelisk navigation" #-}
 linkClass :: DomBuilder t m => Text -> Text -> m (Link t)
 linkClass s c = do
   (l,_) <- elAttr' "a" ("class" =: c) $ text s
   return $ Link $ domEvent Click l
 
-{-# DEPRECATED link "Use 'elAttr'' in combination with 'domEvent' for just clicks. Use 'routeLink' for Obelisk navigation" #-}
 link :: DomBuilder t m => Text -> m (Link t)
 link s = linkClass s ""
 
 divClass :: forall t m a. DomBuilder t m => Text -> m a -> m a
 divClass = elClass "div"
 
-{-# DEPRECATED dtdd "Use an application specific widget generating function" #-}
 dtdd :: forall t m a. DomBuilder t m => Text -> m a -> m a
 dtdd h w = do
   el "dt" $ text h
@@ -301,7 +296,6 @@ blank = return ()
 
 -- TODO: Move to an example project.
 -- | A widget to display a table with static columns and dynamic rows.
-{-# DEPRECATED tableDynAttr "Use an application specific widget generating function" #-}
 tableDynAttr :: forall t m r k v. (Ord k, DomBuilder t m, MonadHold t m, PostBuild t m, MonadFix m)
   => Text                                   -- ^ Class applied to <table> element
   -> [(Text, k -> Dynamic t r -> m v)]      -- ^ Columns of (header, row key -> row value -> child widget)
@@ -321,7 +315,6 @@ tableDynAttr klass cols dRows rowAttrs = elAttr "div" (Map.singleton "style" "zo
 -- | A widget to construct a tabbed view that shows only one of its child widgets at a time.
 --   Creates a header bar containing a <ul> with one <li> per child; clicking a <li> displays
 --   the corresponding child and hides all others.
-{-# DEPRECATED tabDisplay "Use an application specific widget generating function" #-}
 tabDisplay :: forall t m k. (MonadFix m, DomBuilder t m, MonadHold t m, PostBuild t m, Ord k)
   => Text               -- ^ Class applied to <ul> element
   -> Text               -- ^ Class applied to currently active <li> element


### PR DESCRIPTION
These were added in 0.5.3, but ended up being a burden on users. For
now, they will remain in Reflex.Dom.Widget.Basic until a better
alternative emerges. A separate widget toolkit may eventually contain
these opinionated widgets.

Note that deprecations from Reflex.Dom.Widget.Input in 0.5.3 still
stand.
