### PR TITLE
Export hydration attributes

### DIFF
--- a/reflex-dom-core/ChangeLog.md
+++ b/reflex-dom-core/ChangeLog.md
@@ -19,6 +19,10 @@
 
 * Fix bug in hydration when dealing with unexpected HTML ([#361](https://github.com/reflex-frp/reflex-dom/pull/361)).
 
+* Export attributes used for controlling hydration at the element level
+  * "data-ssr" is now available as `hydratableAttribute`
+  * "data-hydration-skip" is now available as `skipHydrationAttribute`
+
 ## 0.5.3
 
 * Deprecate a number of old inflexible widget helpers in `Reflex.Dom.Widget.Basic`:

--- a/reflex-dom-core/ChangeLog.md
+++ b/reflex-dom-core/ChangeLog.md
@@ -20,8 +20,8 @@
 * Fix bug in hydration when dealing with unexpected HTML ([#361](https://github.com/reflex-frp/reflex-dom/pull/361)).
 
 * Export attributes used for controlling hydration at the element level
-  * "data-ssr" is now available as `hydratableAttribute`
-  * "data-hydration-skip" is now available as `skipHydrationAttribute`
+  * "data-ssr" is now available as `Reflex.Dom.Builder.Immediate.hydratableAttribute`
+  * "data-hydration-skip" is now available as `Reflex.Dom.Builder.Immediate.skipHydrationAttribute`
 
 ## 0.5.3
 

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Hydratable.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Hydratable.hs
@@ -21,10 +21,10 @@ import GHCJS.DOM.Types (MonadJSM (..))
 #endif
 import Reflex
 import Reflex.Dom.Builder.Class
-import Reflex.Dom.Builder.Immediate (HasDocument (..))
+import Reflex.Dom.Builder.Immediate (HasDocument (..), hydratableAttribute)
 import Reflex.Host.Class
 
--- | A DomBuilder transformer that adds "data-ssr" to all elements such that the
+-- | A DomBuilder transformer that adds an attribute to all elements such that the
 -- hydration builder knows which bits of DOM were added by us, and which were
 -- added by external scripts.
 newtype HydratableT m a = HydratableT { runHydratableT :: m a } deriving (Functor, Applicative, Monad, MonadAtomicRef, MonadFix, MonadIO)
@@ -62,8 +62,8 @@ instance PrimMonad m => PrimMonad (HydratableT m) where
 
 makeHydratable :: Reflex t => ElementConfig er t m -> ElementConfig er t m
 makeHydratable cfg = cfg
-  { _elementConfig_initialAttributes = Map.insert "data-ssr" "" $ _elementConfig_initialAttributes cfg
-  , _elementConfig_modifyAttributes = fmap (Map.delete "data-ssr") <$> _elementConfig_modifyAttributes cfg
+  { _elementConfig_initialAttributes = Map.insert hydratableAttribute "" $ _elementConfig_initialAttributes cfg
+  , _elementConfig_modifyAttributes = fmap (Map.delete hydratableAttribute) <$> _elementConfig_modifyAttributes cfg
   }
 
 instance PostBuild t m => PostBuild t (HydratableT m) where

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
@@ -107,6 +107,9 @@ module Reflex.Dom.Builder.Immediate
   , WindowConfig (..)
   , Window (..)
   , wrapWindow
+  -- * Attributes for controlling hydration
+  , hydratableAttribute
+  , skipHydrationAttribute
   -- * Internal
   , traverseDMapWithKeyWithAdjust'
   , hoistTraverseWithKeyWithAdjust
@@ -137,6 +140,7 @@ import Data.IntMap.Strict (IntMap)
 import Data.Maybe
 import Data.Monoid ((<>))
 import Data.Some (Some(..))
+import Data.String (IsString)
 import Data.Text (Text)
 import Foreign.JavaScript.Internal.Utils
 import Foreign.JavaScript.TH
@@ -743,6 +747,14 @@ elementInternal elementTag cfg child = getHydrationMode >>= \case
   -> HydrationDomBuilderT HydrationDomSpace DomTimeline HydrationM (Element er HydrationDomSpace DomTimeline, a)
   #-}
 
+-- | An attribute which causes hydration to skip over an element completely.
+skipHydrationAttribute :: IsString s => s
+skipHydrationAttribute = "data-hydration-skip"
+
+-- | An attribute which signals that an element should be hydrated.
+hydratableAttribute :: IsString s => s
+hydratableAttribute = "data-ssr"
+
 {-# INLINE hydrateElement #-}
 hydrateElement
   :: forall er t m a. (MonadJSM m, Reflex t, MonadReflexCreateTrigger t m, MonadFix m)
@@ -764,13 +776,15 @@ hydrateElement elementTag cfg child = do
         }
   result <- HydrationDomBuilderT $ lift $ runReaderT (unHydrationDomBuilderT child) env'
   wrapResult <- liftIO newEmptyMVar
-  let skipAttr = "data-hydration-skip" :: DOM.JSString
-      ssrAttr = "data-ssr" :: DOM.JSString
+  let -- Determine if we should skip an element. We currently skip elements for
+      -- two reasons:
+      -- 1) it was not produced a static builder which supports hydration
+      -- 2) it is explicitly marked to be skipped
       shouldSkip :: DOM.Element -> HydrationRunnerT t m Bool
       shouldSkip e = do
-        skip <- hasAttribute e skipAttr
-        ssr <- hasAttribute e ssrAttr
-        pure $ skip || not ssr
+        skip <- hasAttribute e (skipHydrationAttribute :: DOM.JSString)
+        hydratable <- hasAttribute e (hydratableAttribute :: DOM.JSString)
+        pure $ skip || not hydratable
   childDom <- liftIO $ readIORef childDelayedRef
   let rawCfg = extractRawElementConfig cfg
   doc <- askDocument
@@ -786,7 +800,7 @@ hydrateElement elementTag cfg child = do
           Just node -> DOM.castTo DOM.Element node >>= \case
             Nothing -> go (Just node) -- this node is not an element, skip
             Just e -> shouldSkip e >>= \case
-              True -> go (Just node) -- this element is explicitly marked for being skipped by hydration
+              True -> go (Just node) -- this element is should be skipped by hydration
               False -> do
                 t <- Element.getTagName e
                 -- TODO: check attributes?

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
@@ -778,7 +778,7 @@ hydrateElement elementTag cfg child = do
   wrapResult <- liftIO newEmptyMVar
   let -- Determine if we should skip an element. We currently skip elements for
       -- two reasons:
-      -- 1) it was not produced a static builder which supports hydration
+      -- 1) it was not produced by a static builder which supports hydration
       -- 2) it is explicitly marked to be skipped
       shouldSkip :: DOM.Element -> HydrationRunnerT t m Bool
       shouldSkip e = do
@@ -800,7 +800,7 @@ hydrateElement elementTag cfg child = do
           Just node -> DOM.castTo DOM.Element node >>= \case
             Nothing -> go (Just node) -- this node is not an element, skip
             Just e -> shouldSkip e >>= \case
-              True -> go (Just node) -- this element is should be skipped by hydration
+              True -> go (Just node) -- this element should be skipped by hydration
               False -> do
                 t <- Element.getTagName e
                 -- TODO: check attributes?


### PR DESCRIPTION
This change means consumers (such as obelisk) don't need to hardcode strings