### PR TITLE
Bump version bounds

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -56,16 +56,16 @@ library
     aeson >= 0.8 && < 1.5,
     base >= 4.7 && < 4.14,
     bifunctors >= 4.2 && < 6,
-    bimap >= 0.3 && < 0.4,
+    bimap >= 0.3 && < 0.5,
     blaze-builder >= 0.4.1 && < 0.5,
     bytestring == 0.10.*,
     case-insensitive < 1.3,
     containers >= 0.6 && < 0.7,
-    constraints >= 0.9 && < 0.12,
+    constraints >= 0.9 && < 0.13,
     contravariant >= 1.4 && < 1.6,
     data-default >= 0.5 && < 0.8,
     dependent-map >= 0.3 && < 0.4,
-    dependent-sum >= 0.6 && < 0.7,
+    dependent-sum >= 0.6 && < 0.8,
     dependent-sum-template >= 0.1 && < 0.2,
     directory >= 1.2 && < 1.4,
     exception-transformers == 0.4.*,
@@ -100,7 +100,7 @@ library
   if flag(split-these)
     build-depends:
       semialign >= 1 && < 1.2,
-      these >= 1 && < 1.1
+      these >= 1 && < 1.2
   else
     build-depends:
       these >= 0.4 && < 0.9


### PR DESCRIPTION
I have confirmed that this compiles with those versions via nixpkgs.

I would very much appreciate a hackage revision with these version bounds updated.