### PR TITLE
Add `now` to the `MonadHold` instance for `UnrunnableT`

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -211,6 +211,7 @@ instance Monad m => MonadHold t (UnrunnableT js t m) where
   holdIncremental _ _ = unrunnable
   buildDynamic _ _ = unrunnable
   headE _ = unrunnable
+  now = unrunnable
 instance Monad m => MonadSample t (UnrunnableT js t m) where
   sample _ = unrunnable
 instance Monad m => MonadIO (UnrunnableT js t m) where


### PR DESCRIPTION
Fixes #396 