### PR TITLE
WIP: Fix definition of success in newXMLHttpRequestWithError

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Xhr.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Xhr.hs
@@ -268,7 +268,7 @@ newXMLHttpRequestWithError req cb = do
       readyState <- xmlHttpRequestGetReadyState xhr
       status <- xmlHttpRequestGetStatus xhr
       statusText <- xmlHttpRequestGetStatusText xhr
-      when (readyState == 4) $ do
+      when (readyState == 4 && status /= 0) $ do
         t <- if rt == Just XhrResponseType_Text || isNothing rt
              then xmlHttpRequestGetResponseText xhr
              else return Nothing


### PR DESCRIPTION
Here the sample code demonstrates this change:

```haskell
example :: (MonadWidget t m) => m ()
example = mdo
  failureE <- button "failure"

  divClass "" $ do
    text "getAndDecode"
    simpleList e1Dyn $ el "li" . display

  divClass "" $ do
    text "performRequestAsync"
    simpleList e2Dyn $ el "li" . display

  divClass "" $ do
    text "performRequestAsyncWithError"
    simpleList e3Dyn $ el "li" . display

  e1E :: Event t (Maybe ()) <- getAndDecode
     $ "https://nnnnnnnnnnn"
    <$ failureE

  e2E :: Event t XhrResponse <- performRequestAsync
     $ xhrRequest "GET" "https://nnnnnnnnnnn" def
    <$ failureE

  e3E :: Event t (Either XhrException XhrResponse) <- performRequestAsyncWithError
     $ xhrRequest "GET" "https://nnnnnnnnnnn" def
    <$ failureE

  e1Dyn <- foldDyn (:) [] e1E
  e2Dyn <- foldDyn (:) [] $ fmap (_xhrResponse_statusText) e2E
  e3Dyn <- foldDyn (:) [] $ fmap (fmap _xhrResponse_status) e3E

  return ()

```

Before this change, press the button to cause Xhr error and you got:
![a](https://user-images.githubusercontent.com/5238484/116292190-fecb5100-a7c7-11eb-9929-85aeaf587a67.png)

After this change, press the button to cause Xhr error and you got:
![b](https://user-images.githubusercontent.com/5238484/116292632-7c8f5c80-a7c8-11eb-9cc0-02118ed4b3fc.png)

It's great that `performRequestAsyncWithError` stops returning `Right 0` on error and reports exception correctly. But now `performRequestAsync` and `getAndDecode` become silent, which would need some discussion.

In the case of `performRequestAsync`, it's appropriate to keep silence on error since it return `Event t XhrResponse` and we won't get one on the error case.

For `getAndDecode` which creates `Event t (Maybe a)`, should we map Xhr error to `Nothing` or **not emitting this event**?
