### PR TITLE
Use microlens instead of lens

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -12,7 +12,7 @@ For example:
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Control.Lens ((&), (%~), (.~))
+import Lens.Micro ((&), (%~), (.~))
 import Data.Proxy
 import Reflex.Dom
 

--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -87,7 +87,8 @@ library
     jsaddle >= 0.9.0.0 && < 0.10,
     -- keycode-0.2 has a bug on firefox
     keycode >= 0.2.1 && < 0.3,
-    lens >= 4.7 && < 5,
+    microlens-ghc >= 0.4 && < 0.5,
+    microlens >= 0.4 && < 0.5,
     monad-control >= 1.0.1 && < 1.1,
     mtl >= 2.1 && < 2.3,
     primitive >= 0.5 && < 0.8,
@@ -169,7 +170,8 @@ library
   if flag(use-template-haskell)
     build-depends:
       dependent-sum-template >= 0.1 && < 0.2,
-      template-haskell >= 2.12.0 && < 2.17
+      template-haskell >= 2.12.0 && < 2.17,
+      microlens-th >= 0.4 && < 0.5
     other-extensions: TemplateHaskell
     cpp-options: -DUSE_TEMPLATE_HASKELL
     other-modules:

--- a/reflex-dom-core/src/Foreign/JavaScript/TH.hs
+++ b/reflex-dom-core/src/Foreign/JavaScript/TH.hs
@@ -60,7 +60,7 @@ import Foreign.C.Types
 import Foreign.Ptr
 import Text.Encoding.Z
 #else
-import Control.Lens.Operators ((^.))
+import Lens.Micro.GHC ((^.))
 import Data.Word (Word8)
 import GHCJS.DOM.Types (JSVal, MonadJSM (..), liftJSM, runJSM, toJSString, toJSVal)
 import Language.Javascript.JSaddle (Function (..), array, eval, freeFunction, function, js, js1, jss, valBool,

--- a/reflex-dom-core/src/Foreign/JavaScript/Utils.hs
+++ b/reflex-dom-core/src/Foreign/JavaScript/Utils.hs
@@ -7,7 +7,7 @@ module Foreign.JavaScript.Utils
   , js_jsonParse
   ) where
 
-import Control.Lens
+import Lens.Micro.GHC
 import Data.Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -46,7 +46,7 @@ import Reflex.Query.Class
 import Reflex.Requester.Base
 
 import qualified Control.Category
-import Control.Lens hiding (element)
+import Lens.Micro.GHC
 import Control.Monad.Reader
 import qualified Control.Monad.State as Lazy
 import Control.Monad.State.Strict
@@ -749,7 +749,7 @@ instance HasDocument m => HasDocument (QueryT t q m)
 class HasSetValue a where
   type SetValue a :: *
   setValue :: Lens' a (SetValue a)
-  
+
 instance Reflex t => HasSetValue (TextAreaElementConfig er t m) where
   type SetValue (TextAreaElementConfig er t m) = Event t Text
   setValue = textAreaElementConfig_setValue

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class/TH.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class/TH.hs
@@ -1,8 +1,9 @@
 module Reflex.Dom.Builder.Class.TH where
 
-import Control.Lens
-import Language.Haskell.TH.Lib (DecsQ)
-import Language.Haskell.TH.Syntax (Name, nameBase)
+import Lens.Micro.GHC
+import Lens.Micro.TH
+import Language.Haskell.TH ( mkName, Name, DecsQ, nameBase )
+import Data.Char (toLower)
 
 namer :: [String] -> Name -> [Name] -> Name -> [DefName]
 namer s n ks t | nameBase t `elem` s = []
@@ -10,3 +11,10 @@ namer s n ks t | nameBase t `elem` s = []
 
 makeLensesWithoutField :: [String] -> Name -> DecsQ
 makeLensesWithoutField s = makeLensesWith (lensRules & lensField .~ namer s)
+
+-- copied from lens
+underscoreNoPrefixNamer :: Name -> [Name] -> Name -> [DefName]
+underscoreNoPrefixNamer _ _ n =
+  case nameBase n of
+    '_':x:xs -> [TopName (mkName (toLower x:xs))]
+    _        -> []

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
@@ -119,7 +119,7 @@ module Reflex.Dom.Builder.Immediate
 
 import Control.Concurrent
 import Control.Exception (bracketOnError)
-import Control.Lens (Identity(..), imapM_, iforM_, (^.), makeLenses)
+import Lens.Micro.GHC ( (^.) )
 import Control.Monad.Exception
 import Control.Monad.Primitive
 import Control.Monad.Reader
@@ -133,6 +133,7 @@ import Data.FastMutableIntMap (PatchIntMap (..))
 import Data.Foldable (for_, traverse_)
 import Data.Functor.Compose
 import Data.Functor.Constant
+import Data.Functor.Identity
 import Data.Functor.Misc
 import Data.Functor.Product
 import Data.GADT.Compare (GCompare)
@@ -208,11 +209,13 @@ import qualified Reflex.TriggerEvent.Base as TriggerEventT (askEvents)
 
 #ifndef USE_TEMPLATE_HASKELL
 import Data.Functor.Contravariant (phantom)
-import Control.Lens (Lens', Getter)
+#else
+import Lens.Micro.TH
 #endif
 
 #ifndef ghcjs_HOST_OS
 import GHCJS.DOM.Types (MonadJSM (..))
+import qualified Data.Map as M
 
 instance MonadJSM m => MonadJSM (HydrationRunnerT t m) where
   {-# INLINABLE liftJSM' #-}
@@ -527,7 +530,7 @@ wrap
   -> RawElementConfig er t s
   -> m (DMap EventName (EventFilterTriggerRef t er))
 wrap events e cfg = do
-  forM_ (_rawElementConfig_modifyAttributes cfg) $ \modifyAttrs -> requestDomAction_ $ ffor modifyAttrs $ imapM_ $ \(AttributeName mAttrNamespace n) mv -> case mAttrNamespace of
+  forM_ (_rawElementConfig_modifyAttributes cfg) $ \modifyAttrs -> requestDomAction_ $ ffor (M.toList <$> modifyAttrs) $ mapM_ $ \(AttributeName mAttrNamespace n, mv) -> case mAttrNamespace of
     Nothing -> maybe (removeAttribute e n) (setAttribute e n) mv
     Just ns -> maybe (removeAttributeNS e (Just ns) n) (setAttributeNS e (Just ns) n) mv
   eventTriggerRefs :: DMap EventName (EventFilterTriggerRef t er) <- liftJSM $ fmap DMap.fromList $ forM (DMap.toList $ _ghcjsEventSpec_filters $ _rawElementConfig_eventSpec cfg) $ \(en :=> GhcjsEventFilter f) -> do
@@ -680,7 +683,7 @@ makeElement doc elementTag cfg = do
   e <- uncheckedCastTo DOM.Element <$> case cfg ^. namespace of
     Nothing -> createElement doc elementTag
     Just ens -> createElementNS doc (Just ens) elementTag
-  iforM_ (cfg ^. initialAttributes) $ \(AttributeName mAttrNamespace n) v -> case mAttrNamespace of
+  forM_ (M.toList $ cfg ^. initialAttributes) $ \(AttributeName mAttrNamespace n, v) -> case mAttrNamespace of
     Nothing -> setAttribute e n v
     Just ans -> setAttributeNS e (Just ans) n v
   pure e

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -17,7 +17,7 @@ module Reflex.Dom.Builder.Static where
 
 import Data.IORef (IORef)
 import Blaze.ByteString.Builder.Html.Utf8
-import Control.Lens hiding (element)
+import Lens.Micro.GHC
 import Control.Monad.Exception
 import Control.Monad.Identity
 import Control.Monad.Primitive

--- a/reflex-dom-core/src/Reflex/Dom/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Class.hs
@@ -4,7 +4,8 @@ module Reflex.Dom.Class ( module Reflex.Dom.Class
                         , module Web.KeyCode
                         ) where
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.Internal
 import Reflex.Class
 import Web.KeyCode
 

--- a/reflex-dom-core/src/Reflex/Dom/Location.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Location.hs
@@ -22,7 +22,7 @@ module Reflex.Dom.Location
 import Reflex
 import Reflex.Dom.Builder.Immediate (wrapDomEvent)
 
-import Control.Lens ((^.))
+import Lens.Micro.GHC ((^.))
 import Control.Monad ((>=>))
 import Control.Monad.Fix (MonadFix)
 import Data.Align (align)

--- a/reflex-dom-core/src/Reflex/Dom/Main.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Main.hs
@@ -31,13 +31,13 @@ import Reflex.Profiled
 #endif
 
 import Control.Concurrent
-import Control.Lens
 import Control.Monad
 import Control.Monad.Reader hiding (forM, forM_, mapM, mapM_, sequence, sequence_)
 import Control.Monad.Ref
 import Data.ByteString (ByteString)
 import Data.Dependent.Sum (DSum (..))
 import Data.Foldable (for_)
+import Data.Functor.Identity
 import Data.IORef
 import Data.Maybe
 import Data.Monoid ((<>))

--- a/reflex-dom-core/src/Reflex/Dom/Old.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Old.hs
@@ -46,10 +46,9 @@ module Reflex.Dom.Old
 
 import Control.Arrow (first)
 #ifdef USE_TEMPLATE_HASKELL
-import Control.Lens (makeLenses, (%~), (&), (.~), (^.))
-#else
-import Control.Lens (Lens, Lens', (%~), (&), (.~), (^.))
+import Lens.Micro.TH (makeLenses)
 #endif
+import Lens.Micro.GHC ((%~), (&), (.~), (^.))
 import Control.Monad
 import Control.Monad.Fix
 import Control.Monad.IO.Class

--- a/reflex-dom-core/src/Reflex/Dom/WebSocket.hs
+++ b/reflex-dom-core/src/Reflex/Dom/WebSocket.hs
@@ -40,7 +40,7 @@ import Reflex.TriggerEvent.Class
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Exception
-import Control.Lens
+import Lens.Micro.GHC
 import Control.Monad hiding (forM, forM_, mapM, mapM_, sequence)
 import Control.Monad.IO.Class
 import Control.Monad.State
@@ -58,6 +58,9 @@ import GHCJS.DOM.Types (runJSM, askJSM, MonadJSM, liftJSM, JSM)
 import GHCJS.DOM.WebSocket (getReadyState)
 import GHCJS.Marshal
 import qualified Language.Javascript.JSaddle.Monad as JS (catch)
+#ifdef USE_TEMPLATE_HASKELL
+import Lens.Micro.TH
+#endif
 
 data WebSocketConfig t a
    = WebSocketConfig { _webSocketConfig_send :: Event t [a]

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
@@ -18,7 +18,7 @@ module Reflex.Dom.Widget.Input (module Reflex.Dom.Widget.Input, def, (&), (.~)) 
 
 import Prelude
 
-import Control.Lens hiding (element, ix)
+import Lens.Micro.GHC ( (&), (.~) )
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Reader
@@ -50,7 +50,9 @@ import Reflex.Dynamic
 import Reflex.PostBuild.Class
 import Reflex.TriggerEvent.Class
 import qualified Text.Read as T
-
+#ifdef USE_TEMPLATE_HASKELL
+import Lens.Micro.TH
+#endif
 import qualified GHCJS.DOM.Event as Event
 import qualified GHCJS.DOM.HTMLInputElement as Input
 

--- a/reflex-dom-core/src/Reflex/Dom/Xhr.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Xhr.hs
@@ -5,9 +5,9 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-#ifdef USE_TEMPLATE_HASKELL
+
 {-# LANGUAGE TemplateHaskell #-}
-#endif
+
 
 -- | A module for performing asynchronous HTTP calls from JavaScript
 -- using the
@@ -149,15 +149,15 @@ import Reflex.Dom.Xhr.ResponseType
 
 import Control.Concurrent
 import Control.Exception (handle)
-import Control.Lens
+import Lens.Micro.GHC
 import Control.Monad hiding (forM)
 import Control.Monad.IO.Class
 import Data.Aeson
-#if MIN_VERSION_aeson(1,0,0)
+
 import Data.Aeson.Text
-#else
-import Data.Aeson.Encode
-#endif
+
+
+
 import qualified Data.ByteString.Lazy as BL
 import Data.CaseInsensitive (CI)
 import qualified Data.CaseInsensitive as CI
@@ -175,7 +175,11 @@ import qualified Data.Text.Lazy.Builder as B
 import Data.Traversable
 import Data.Typeable
 
+import Lens.Micro.TH
+
+
 import Language.Javascript.JSaddle.Monad (JSM, askJSM, runJSM, MonadJSM, liftJSM)
+import qualified Data.Map as M
 
 data XhrRequest a
    = XhrRequest { _xhrRequest_method :: Text
@@ -261,7 +265,7 @@ newXMLHttpRequestWithError req cb = do
       True
       (fromMaybe "" $ _xhrRequestConfig_user c)
       (fromMaybe "" $ _xhrRequestConfig_password c)
-    iforM_ (_xhrRequestConfig_headers c) $ xmlHttpRequestSetRequestHeader xhr
+    forM_ (M.toList $ _xhrRequestConfig_headers c) $ uncurry (xmlHttpRequestSetRequestHeader xhr)
     maybe (return ()) (xmlHttpRequestSetResponseType xhr . fromResponseType) rt
     xmlHttpRequestSetWithCredentials xhr creds
     _ <- xmlHttpRequestOnreadystatechange xhr $ do

--- a/reflex-dom-core/src/Reflex/Dom/Xhr/FormData.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Xhr/FormData.hs
@@ -7,7 +7,7 @@ module Reflex.Dom.Xhr.FormData
   )
   where
 
-import Control.Lens
+import Lens.Micro.GHC
 import Data.Default
 import Data.Map (Map)
 import Data.Text (Text)
@@ -19,6 +19,8 @@ import GHCJS.DOM.Types (File, IsBlob)
 import Language.Javascript.JSaddle.Monad (MonadJSM, liftJSM)
 import Reflex
 import Reflex.Dom.Xhr
+import qualified Data.Map as M
+import Control.Monad
 
 -- | A FormData value may be a blob/file or a string. The file can optionally be provided with filename.
 data FormValue blob = FormValue_Text Text
@@ -35,7 +37,7 @@ postForms
 postForms url payload = do
   performMkRequestsAsync $ ffor payload $ \fs -> for fs $ \u -> liftJSM $ do
     fd <- FD.newFormData Nothing
-    iforM_ u $ \k v -> case v of
+    forM_ (M.toList u) $ \(k, v) -> case v of
       FormValue_Text t -> FD.append fd k t
       FormValue_File b fn -> FD.appendBlob fd k b fn
     return $ xhrRequest "POST" url $ def & xhrRequestConfig_sendData .~ fd

--- a/reflex-dom-core/test/hydration.hs
+++ b/reflex-dom-core/test/hydration.hs
@@ -31,7 +31,7 @@
 import Prelude hiding (fail)
 import Control.Concurrent
 import qualified Control.Concurrent.Async as Async
-import Control.Lens.Operators
+import Lens.Micro.GHC.Operators
 import Control.Monad hiding (fail)
 import Control.Monad.Catch
 import Control.Monad.Fail

--- a/reflex-dom/examples/sortableList.hs
+++ b/reflex-dom/examples/sortableList.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-import Control.Lens
+import Lens.Micro.GHC
 import Control.Monad.Identity
 import Control.Monad.IO.Class
 import Data.Dependent.Map (DMap)


### PR DESCRIPTION
A major use case for reflex-dom is making frontend applications. This means that the compiled binaries are shipped to the user. In some cases, they are loaded when the user opens a web page. This means, that size is quite important.

`lens` has a pretty big dependency footprint, and most of the library isn't even used in reflex-dom. This PR removes the `lens` dependencies from libraries.