### PR TITLE
Remove OS restriction for use-warp mode

### DIFF
--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -77,7 +77,7 @@ library
     reflex-dom-core >= 0.6.1.0 && <0.7,
     text == 1.2.*
   if !impl(ghcjs)
-    if flag(use-warp) && (os(linux) || os(osx))
+    if flag(use-warp)
       build-depends:
         jsaddle >= 0.9.6 && < 0.10,
         jsaddle-warp >= 0.9.6 && < 0.10


### PR DESCRIPTION
As mentioned in #414, removing these restrictions allows reflex-dom to build on Windows.

Since there isn't any test suite for reflex-dom and the test suite for reflex-dom-core is currently incompatible with Windows, the best I could do for testing is try to use reflex-dom to make [an example site I found](https://github.com/typeable/blog-posts-ru/tree/680581203f0fd5f7fe0714d9d8778e9426010ea7/reflex-todo), since the built-in example is broken (see #422).

The site appeared to work fine on Chrome, but was completely unresponsive on Firefox, though I'm unsure if this is a Windows issue or an issue for reflex-dom in general.

Either way I think the best solution is to remove this restriction and let any windows bugs bubble up as issues, rather than barring a user from compiling under windows entirely, since the latter will turn away potential Windows users and therefore potential contributors to windows compatibility. 

Fixes #414

