### PR TITLE
Remove unused imports

### DIFF
--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -57,7 +57,6 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
 import Data.Proxy
-import Data.Semigroup
 import Data.Semigroup.Commutative
 import Data.String
 import Data.Text (Text)
@@ -750,7 +749,7 @@ instance HasDocument m => HasDocument (QueryT t q m)
 class HasSetValue a where
   type SetValue a :: *
   setValue :: Lens' a (SetValue a)
-  
+
 instance Reflex t => HasSetValue (TextAreaElementConfig er t m) where
   type SetValue (TextAreaElementConfig er t m) = Event t Text
   setValue = textAreaElementConfig_setValue

--- a/reflex-dom-core/src/Reflex/Dom/Location.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Location.hs
@@ -26,7 +26,6 @@ import Control.Lens ((^.))
 import Control.Monad ((>=>))
 import Control.Monad.Fix (MonadFix)
 import Data.Align (align)
-import Data.Monoid
 import Data.Text (Text)
 import Data.These (These(..))
 import qualified GHCJS.DOM as DOM

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -30,7 +30,6 @@ import Data.Semigroup (Semigroup)
 import Data.Semigroup.Commutative
 import Data.Text (Text)
 import Data.Void
-import Foreign.JavaScript.TH
 import GHCJS.DOM.Types (MonadJSM)
 import Reflex hiding (askEvents)
 import Reflex.Dom.Builder.Class

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -70,7 +70,6 @@ import Reflex.Network
 import Reflex.PostBuild.Class
 import Reflex.Workflow
 
-import Control.Arrow
 import Control.Lens hiding (children, element)
 import Control.Monad.Reader hiding (forM, forM_, mapM, mapM_, sequence, sequence_)
 import Data.Align

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
@@ -30,7 +30,6 @@ import Data.Functor.Misc
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
-import Data.Semigroup
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHCJS.DOM.HTMLInputElement (HTMLInputElement)

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Lazy.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Lazy.hs
@@ -20,7 +20,6 @@ import Control.Monad.Fix
 import Data.Fixed
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHCJS.DOM.Element

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Resize.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Resize.hs
@@ -16,12 +16,10 @@ import Reflex.PerformEvent.Class
 import Reflex.PostBuild.Class
 import Reflex.TriggerEvent.Class
 
-import Control.Monad
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHCJS.DOM.Element

--- a/reflex-dom-core/src/Reflex/Dom/Xhr/FormData.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Xhr/FormData.hs
@@ -14,7 +14,6 @@ import Data.Map (Map)
 import Data.Text (Text)
 import Data.Traversable
 import qualified GHCJS.DOM.FormData as FD
-import Foreign.JavaScript.TH
 import GHCJS.DOM.File (getName)
 import GHCJS.DOM.Types (File, IsBlob)
 import Language.Javascript.JSaddle.Monad (MonadJSM, liftJSM)


### PR DESCRIPTION
These pollute the terminal quite a bit and make it harder to see warnings related to what one's actually working on.
Tested with ghc 8.6.5, letting CI check the others due to the whole semigroup-monoid transition