### PR TITLE
Bump reflex-platform

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -3,6 +3,6 @@
   "repo": "reflex-platform",
   "branch": "develop",
   "private": false,
-  "rev": "ac66356c8839d1dc16cc60887c2db5988a60e6c4",
-  "sha256": "0zk8pf72lid6cqq4mlr1mcwh6zd5lz9i83kw519aci6mfba1afvq"
+  "rev": "34c75631e7f2dd1409847b9df57252b96737e73a",
+  "sha256": "1nwyybjy65b7qnb62wcm74nqfndr8prr2xsfvaianps0yzm366d0"
 }

--- a/dep/reflex-platform/thunk.nix
+++ b/dep/reflex-platform/thunk.nix
@@ -2,7 +2,10 @@
 let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
   if !fetchSubmodules && !private then builtins.fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
-  } else (import <nixpkgs> {}).fetchFromGitHub {
+  } else (import (builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/3aad50c30c826430b0270fcf8264c8c41b005403.tar.gz";
+  sha256 = "0xwqsf08sywd23x0xvw4c4ghq0l28w2ki22h0bdn766i16z9q2gr";
+}) {}).fetchFromGitHub {
     inherit owner repo rev sha256 fetchSubmodules private;
   };
   json = builtins.fromJSON (builtins.readFile ./github.json);

--- a/release.nix
+++ b/release.nix
@@ -23,23 +23,6 @@ let
       reflex-platform = reflex-platform-fun {
         inherit system;
         haskellOverlays = [
-          (self: super: {
-            commutative-semigroups = self.callHackageDirect {
-              pkg = "commutative-semigroups";
-              ver = "0.1.0.0";
-              sha256 = "0xmv20n3iqjc64xi3c91bwqrg8x79sgipmflmk21zz4rj9jdkv8i";
-            } {};
-            reflex = self.callHackageDirect {
-              pkg = "reflex";
-              ver = "0.8.2.1";
-              sha256 = "10d1qkqwaqp9zaswmziaqgz60ifg5383d2i2ml2cqccn8943h26b";
-            } {};
-            patch = self.callHackageDirect {
-              pkg = "patch";
-              ver = "0.0.7.0";
-              sha256 = "0yr2hk3fpwjxi1z0n384k3aq9b3z00c02bbwqybcj3n20l4k17l6";
-            } {};
-          })
           # Use this package's source for reflex
           (self: super: {
             _dep = super._dep // {


### PR DESCRIPTION
Needed this to be able to use `./dep/reflex-platform/scripts/work-on reflex-dom-core`.
Without the changes in https://github.com/reflex-frp/reflex-platform/pull/786 I'm getting cabal build plan failures.
Was confused by the fact release.nix still built reflex-dom just fine until I noticed the local overrides, so I removed those now that they're included upstream.