### PR TITLE
Use https scheme and appassets.androidplatform.net instead of file:// for android.

### DIFF
--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -41,8 +41,6 @@ public class MainWidget {
     a.setContentView(wv);
     final WebSettings ws = wv.getSettings();
     ws.setJavaScriptEnabled(true);
-    ws.setAllowFileAccessFromFileURLs(true);
-    ws.setAllowUniversalAccessFromFileURLs(true);
     ws.setDomStorageEnabled(true);
     wv.setWebContentsDebuggingEnabled(true);
     // allow video to play without user interaction
@@ -64,7 +62,8 @@ public class MainWidget {
         @Override
         public WebResourceResponse shouldInterceptRequest (WebView view, WebResourceRequest request) {
             Uri uri = request.getUrl();
-            if(!uri.getScheme().equals("file"))
+	    Log.i("reflex", uri.toString());
+            if(!uri.getScheme().equals("file") && !uri.getEncodedAuthority().equals("appassets.androidplatform.net"))
                 return null;
 
             String path = uri.getPath();

--- a/reflex-dom/src/Reflex/Dom/Internal.hs
+++ b/reflex-dom/src/Reflex/Dom/Internal.hs
@@ -76,7 +76,7 @@ run jsm = do
   continueWithCallbacks $ def
     { _activityCallbacks_onCreate = \_ -> do
         a <- getHaskellActivity
-        let startPage = fromString "file:///android_asset/index.html"
+        let startPage = fromString "https:///appassets.androidplatform.net/index.html"
         startMainWidget a startPage jsm
     }
   forever $ threadDelay 1000000000


### PR DESCRIPTION
This follows the usage recommended at
https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader to avoid an issue where assets referred to by file:// urls would receive a permissions error and never be passed to shouldInterceptRequest in sufficiently high API levels.

It may be appropriate to expose a method to use a different base URI, which could simplify CORS for android apps in some use cases, and additionally a full conversion to WebViewAssetLoader might be reasonable.