### PR TITLE
History management for android

### DIFF
--- a/reflex-dom/cbits/MainWidget.c
+++ b/reflex-dom/cbits/MainWidget.c
@@ -53,6 +53,40 @@ void Reflex_Dom_Android_MainWidget_runJS(jobject jsExecutor, const char* js, siz
   (*env)->PopLocalFrame(env, 0);
 }
 
+void Reflex_Dom_Android_MainWidget_back(jobject jsExecutor) {
+  JNIEnv *env;
+  jint attachResult = (*HaskellActivity_jvm)->AttachCurrentThread(HaskellActivity_jvm, &env, NULL);
+  assert (attachResult == JNI_OK);
+
+  (*env)->PushLocalFrame(env, 5);
+
+  //TODO: Don't search for this method every time
+  jclass cls = (*env)->GetObjectClass(env, jsExecutor);
+  assert(cls);
+  jmethodID evaluateJavascript = (*env)->GetMethodID(env, cls, "goBack", "()V");
+  assert(evaluateJavascript);
+  (*env)->CallVoidMethod(env, jsExecutor, evaluateJavascript);
+
+  (*env)->PopLocalFrame(env, 0);
+}
+
+void Reflex_Dom_Android_MainWidget_clearHistory(jobject jsExecutor) {
+  JNIEnv *env;
+  jint attachResult = (*HaskellActivity_jvm)->AttachCurrentThread(HaskellActivity_jvm, &env, NULL);
+  assert (attachResult == JNI_OK);
+
+  (*env)->PushLocalFrame(env, 5);
+
+  //TODO: Don't search for this method every time
+  jclass cls = (*env)->GetObjectClass(env, jsExecutor);
+  assert(cls);
+  jmethodID evaluateJavascript = (*env)->GetMethodID(env, cls, "clearHistory", "()V");
+  assert(evaluateJavascript);
+  (*env)->CallVoidMethod(env, jsExecutor, evaluateJavascript);
+
+  (*env)->PopLocalFrame(env, 0);
+}
+
 JNIEXPORT void JNICALL Java_org_reflexfrp_reflexdom_MainWidget_00024JSaddleCallbacks_startProcessing (JNIEnv *env, jobject thisObj, jlong callbacksLong) {
   const JSaddleCallbacks *callbacks = (const JSaddleCallbacks *)callbacksLong;
   (*(callbacks->jsaddleStart))();

--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -156,14 +156,6 @@ public class MainWidget {
 	  }
 	});
       }
-      public final void clearHistory() {
-        hnd.post(new Runnable() {
-          @Override
-	  public void run() {
-            wv.clearHistory();
-	  }
-        });
-      }
     };
   }
 

--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -41,8 +41,6 @@ public class MainWidget {
     a.setContentView(wv);
     final WebSettings ws = wv.getSettings();
     ws.setJavaScriptEnabled(true);
-    ws.setAllowFileAccessFromFileURLs(true);
-    ws.setAllowUniversalAccessFromFileURLs(true);
     ws.setDomStorageEnabled(true);
     wv.setWebContentsDebuggingEnabled(true);
     // allow video to play without user interaction
@@ -64,7 +62,8 @@ public class MainWidget {
         @Override
         public WebResourceResponse shouldInterceptRequest (WebView view, WebResourceRequest request) {
             Uri uri = request.getUrl();
-            if(!uri.getScheme().equals("file"))
+	    Log.i("reflex", uri.toString());
+            if(!uri.getScheme().equals("file") && !uri.getEncodedAuthority().equals("appassets.androidplatform.net"))
                 return null;
 
             String path = uri.getPath();

--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -86,7 +86,7 @@ public class MainWidget {
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
-            if( url != null && !url.startsWith("http://") && !url.startsWith("https://") && !url.startsWith("file://")) {
+            if( url != null && !url.startsWith("http://appassets.androidplatform.net") && !url.startsWith("https://appassets.androidplatform.net") && !url.startsWith("file://")) {
                 try {
                     view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
                 }
@@ -143,6 +143,26 @@ public class MainWidget {
               wv.evaluateJavascript(jsStr, null);
             }
           });
+      }
+      public final void goBack() {
+        hnd.post(new Runnable() {
+          @Override
+	  public void run() {
+            if(wv.canGoBack()) {
+              wv.goBack();
+            } else {
+              a.defaultOnBackPressed();
+            }
+	  }
+	});
+      }
+      public final void clearHistory() {
+        hnd.post(new Runnable() {
+          @Override
+	  public void run() {
+            wv.clearHistory();
+	  }
+        });
       }
     };
   }

--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -104,6 +104,7 @@ library
   exposed-modules:
     Reflex.Dom
     Reflex.Dom.Internal
+    Reflex.Dom.Location.Platform
   reexported-modules:
       Foreign.JavaScript.Orphans
     , Foreign.JavaScript.TH

--- a/reflex-dom/src-android/Reflex/Dom/Android/MainWidget.hsc
+++ b/reflex-dom/src-android/Reflex/Dom/Android/MainWidget.hsc
@@ -2,11 +2,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Reflex.Dom.Android.MainWidget
   ( startMainWidget
+  , clearHistory
+  , goBack
+  , JSExecutor(..)
+  , withGlobalJSExecutor
   ) where
 
 import Android.HaskellActivity
 import Control.Concurrent
 import Control.Monad
+import Control.Monad.IO.Class
 import Data.Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -23,9 +28,9 @@ import Foreign.Storable
 import Language.Javascript.JSaddle (JSM)
 import Language.Javascript.JSaddle.Run (runJavaScript)
 import Language.Javascript.JSaddle.Run.Files (initState, runBatch, ghcjsHelpers)
+import System.IO.Unsafe
 
 #include "MainWidget.h"
-
 
 startMainWidget :: HaskellActivity -> ByteString -> JSM () -> IO ()
 startMainWidget a url jsm = do
@@ -57,13 +62,28 @@ startMainWidget a url jsm = do
         \jsaddle.postReady();\n"
     }
   BS.useAsCString url $ \curl -> do
-    writeIORef executorRef =<< startMainWidget_ a curl callbacks
+    executor <- startMainWidget_ a curl callbacks
+    writeIORef executorRef executor
+    writeIORef globalJSExecutor $ Just executor
 
 newtype JSExecutor = JSExecutor { unJSExecutor :: Ptr JSExecutor }
+
+-- Ugh. But not doing this is also unfortunate for being able to clear the history so that the "back" list is good.
+globalJSExecutor :: IORef (Maybe JSExecutor)
+globalJSExecutor = unsafePerformIO $ newIORef Nothing
+
+withGlobalJSExecutor :: MonadIO m => (JSExecutor -> IO ()) -> m ()
+withGlobalJSExecutor f = liftIO $ do
+  executor <- readIORef globalJSExecutor
+  case executor of
+    Just e -> f e
+    _ -> pure ()
 
 foreign import ccall safe "Reflex_Dom_Android_MainWidget_start" startMainWidget_ :: HaskellActivity -> CString -> Ptr JSaddleCallbacksPtrs -> IO JSExecutor
 
 foreign import ccall safe "Reflex_Dom_Android_MainWidget_runJS" runJS :: JSExecutor -> CString -> CSize -> IO ()
+foreign import ccall safe "Reflex_Dom_Android_MainWidget_clearHistory" clearHistory :: JSExecutor -> IO ()
+foreign import ccall safe "Reflex_Dom_Android_MainWidget_back" goBack :: JSExecutor -> IO ()
 
 data JSaddleCallbacks = JSaddleCallbacks
   { _jsaddleCallbacks_jsaddleStart :: IO ()

--- a/reflex-dom/src-android/Reflex/Dom/Android/MainWidget.hsc
+++ b/reflex-dom/src-android/Reflex/Dom/Android/MainWidget.hsc
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Reflex.Dom.Android.MainWidget
   ( startMainWidget
-  , clearHistory
   , goBack
   , JSExecutor(..)
   , withGlobalJSExecutor
@@ -82,7 +81,6 @@ withGlobalJSExecutor f = liftIO $ do
 foreign import ccall safe "Reflex_Dom_Android_MainWidget_start" startMainWidget_ :: HaskellActivity -> CString -> Ptr JSaddleCallbacksPtrs -> IO JSExecutor
 
 foreign import ccall safe "Reflex_Dom_Android_MainWidget_runJS" runJS :: JSExecutor -> CString -> CSize -> IO ()
-foreign import ccall safe "Reflex_Dom_Android_MainWidget_clearHistory" clearHistory :: JSExecutor -> IO ()
 foreign import ccall safe "Reflex_Dom_Android_MainWidget_back" goBack :: JSExecutor -> IO ()
 
 data JSaddleCallbacks = JSaddleCallbacks

--- a/reflex-dom/src/Reflex/Dom/Internal.hs
+++ b/reflex-dom/src/Reflex/Dom/Internal.hs
@@ -9,7 +9,6 @@ module Reflex.Dom.Internal
   , mainWidget
   , mainWidgetWithHead, mainWidgetWithCss, mainWidgetWithHead', mainWidgetInElementById, runApp'
   , mainHydrationWidgetWithHead, mainHydrationWidgetWithHead'
-  , clearHistory -- Doesn't really belong here, but we need it.
   ) where
 
 import Data.ByteString (ByteString)
@@ -40,8 +39,6 @@ run jsm = do
   putStrLn $ "Running jsaddle-warp server on port " <> show port
   JW.run port jsm
 
-clearHistory :: JSM ()
-clearHistory = pure ()
 #elif defined(MIN_VERSION_jsaddle_wkwebview)
 #if defined(ios_HOST_OS)
 import Data.Default
@@ -61,8 +58,6 @@ run jsm = do
     Just p -> return $ "file://" <> p <> "/index.html"
   run' def $ jsaddleMainHTMLWithBaseURL indexHtml baseUrl jsm
 
-clearHistory :: JSM ()
-clearHistory = pure ()
 #else
 import Language.Javascript.JSaddle.WKWebView (run)
 #endif
@@ -76,8 +71,7 @@ import Data.Default
 import Data.IORef
 import Data.Maybe
 import Data.String
-import Reflex.Dom.Android.MainWidget hiding (clearHistory)
-import qualified Reflex.Dom.Android.MainWidget
+import Reflex.Dom.Android.MainWidget
 import System.IO
 import System.IO.Unsafe
 import Language.Javascript.JSaddle (JSM, eval)
@@ -95,9 +89,6 @@ run jsm = do
     }
   forever $ threadDelay 1000000000
 
-clearHistory :: MonadIO m => m ()
-clearHistory = withGlobalJSExecutor Reflex.Dom.Android.MainWidget.clearHistory
-
 triggerBackButton :: MonadIO m => m ()
 triggerBackButton = withGlobalJSExecutor goBack
 
@@ -107,13 +98,9 @@ import Language.Javascript.JSaddle (JSM)
 run :: JSM () -> IO ()
 run = Wasm.run 0
 
-clearHistory :: JSM ()
-clearHistory = pure ()
 #else
 import Language.Javascript.JSaddle.WebKitGTK (run)
 
-clearHistory :: Monad m => m ()
-clearHistory = pure ()
 #endif
 
 mainWidget :: (forall x. Widget x ()) -> IO ()

--- a/reflex-dom/src/Reflex/Dom/Internal.hs
+++ b/reflex-dom/src/Reflex/Dom/Internal.hs
@@ -76,7 +76,7 @@ run jsm = do
   continueWithCallbacks $ def
     { _activityCallbacks_onCreate = \_ -> do
         a <- getHaskellActivity
-        let startPage = fromString "file:///android_asset/index.html"
+        let startPage = fromString "https:///appassets.androidplatform.net/index.html"
         startMainWidget a startPage jsm
     }
   forever $ threadDelay 1000000000

--- a/reflex-dom/src/Reflex/Dom/Location/Platform.hs
+++ b/reflex-dom/src/Reflex/Dom/Location/Platform.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+#if defined(ANDROID)
+module Reflex.Dom.Location.Platform where
+
+import Reflex
+import Control.Monad.IO.Class
+import Reflex.Dom.Android.MainWidget
+
+popHistoryState
+  :: (PerformEvent t m, MonadIO (Performable m))
+  => Event t ()
+  -> m ()
+popHistoryState evt = performEvent_ $ withGlobalJSExecutor goBack <$ evt
+#else
+module Reflex.Dom.Location.Platform (Reflex.Dom.Location.popHistoryState) where
+import qualified Reflex.Dom.Location
+
+#endif
+


### PR DESCRIPTION
Adds support for the "back" button in android, adds a function to trigger platform-dependent "back" handling (which on Android includes exiting the app if the history is empty), and extends manageHistory slightly to allow additional behavior on external history navigation such as skipping updates that would now reroute when going backwards.