### PR TITLE
Hydration test fixes for spurious failures/hangs

### DIFF
--- a/reflex-dom-core/test/hydration.hs
+++ b/reflex-dom-core/test/hydration.hs
@@ -89,9 +89,6 @@ import qualified Test.WebDriver.Capabilities as WD
 import Test.Util.ChromeFlags
 import Test.Util.UnshareNetwork
 
--- ORPHAN: https://github.com/kallisti-dev/hs-webdriver/pull/167
-deriving instance MonadMask WD
-
 chromium :: FilePath
 chromium = $(staticWhich "chromium")
 


### PR DESCRIPTION
The issues and fixes were identified by running the tests locally multiple times, using cabal-build's test binaries.
I have not observed issues in nix-build locally or on CI so far, but these fixes should avoid their occurrences.
For the MonadMask instance using the webdriver >= "0.10.0.0" is necessary