### PR TITLE
Remove non-conditional dep gated by flag

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -86,7 +86,6 @@ library
     data-default >= 0.5 && < 0.9,
     dependent-map >= 0.3 && < 0.5,
     dependent-sum >= 0.6 && < 0.8,
-    dependent-sum-template >= 0.1 && < 0.3,
     directory >= 1.2 && < 1.4,
     exception-transformers == 0.4.*,
     ghcjs-dom >= 0.9.1.0 && < 0.10,


### PR DESCRIPTION
If the point of 
https://github.com/reflex-frp/reflex-dom/blob/3b26fac4e76de24e75f1e71ad3f6c8ae1eff219c/reflex-dom-core/reflex-dom-core.cabal#L169-L172

is avoiding dependency on template-haskell on some platforms, then it seems strange to always depend on dependent-sum-template which brings template-haskell anyway?
