### PR TITLE
Bump reflex-platform

### DIFF
--- a/dep/reflex-platform/github.json
+++ b/dep/reflex-platform/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "reflex-frp",
   "repo": "reflex-platform",
-  "branch": "release/1.0.1.0",
+  "branch": "release/1.2.0.0",
   "private": false,
-  "rev": "50099ce2bca93ef69cea615ec72152b4a7648de4",
-  "sha256": "1ldzf3qznpysf4drkrvj7ysmdvrv6ddprnniylvcxccpp0f4krb7"
+  "rev": "f231e2425ac92339b8491cdd970930d63d9ad1ad",
+  "sha256": "0b042x423p04shhidni08f47ydgpfj0rpqhb0m6gj2lg8b3s9l8k"
 }

--- a/release.nix
+++ b/release.nix
@@ -22,24 +22,7 @@ let
       reflex-platform = reflex-platform-fun {
         inherit system;
         haskellOverlays = [
-          (self: super: {
-            commutative-semigroups = self.callHackageDirect {
-              pkg = "commutative-semigroups";
-              ver = "0.1.0.0";
-              sha256 = "0xmv20n3iqjc64xi3c91bwqrg8x79sgipmflmk21zz4rj9jdkv8i";
-            } {};
-            reflex = self.callHackageDirect {
-              pkg = "reflex";
-              ver = "0.9.0.1";
-              sha256 = "sha256-HhBBElxwfzGt1tOMCtYLT9Ody9mvaDb2ppuy3qFWLPs=";
-            } {};
-            patch = self.callHackageDirect {
-              pkg = "patch";
-              ver = "0.0.8.2";
-              sha256 = "sha256-7+dwuBNo33XPsBo5DhFD4oyKBWrOvTHUyA6RJyHGH5g=";
-            } {};
-          })
-          # Use this package's source for reflex
+          # Use this package's source for reflex-dom
           (self: super: {
             _dep = super._dep // {
               reflex-dom = builtins.filterSource (path: type: !(builtins.elem (baseNameOf path) [


### PR DESCRIPTION
Android build currently fails in nix CI with
```
Configuring reflex-dom-0.6.3.1...
CallStack (from HasCallStack):
  die', called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:950:20 in Cabal-2.4.0.1:Distribution.Simple.Configure
  configureFinalizedPackage, called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:460:12 in Cabal-2.4.0.1:Distribution.Simple.Configure
  configure, called at libraries/Cabal/Cabal/Distribution/Simple.hs:596:20 in Cabal-2.4.0.1:Distribution.Simple
  confHook, called at libraries/Cabal/Cabal/Distribution/Simple/UserHooks.hs:67:5 in Cabal-2.4.0.1:Distribution.Simple.UserHooks
  configureAction, called at libraries/Cabal/Cabal/Distribution/Simple.hs:178:19 in Cabal-2.4.0.1:Distribution.Simple
  defaultMainHelper, called at libraries/Cabal/Cabal/Distribution/Simple.hs:115:27 in Cabal-2.4.0.1:Distribution.Simple
  defaultMain, called at Setup.hs:2:8 in main:Main
Setup: Encountered missing dependencies:
android-activity ==0.2.*
```