### PR TITLE
Allow cross-origin cookies in Android WebView

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -138,6 +138,7 @@ library
     Reflex.Dom.Old
     Reflex.Dom.Prerender
     Reflex.Dom.Time
+    Reflex.Dom.Tutorial
     Reflex.Dom.WebSocket
     Reflex.Dom.WebSocket.Query
     Reflex.Dom.Widget

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class.hs
@@ -23,6 +23,64 @@
 #endif
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- |
+-- Module: Reflex.Dom.Builder.Class
+--
+-- The core abstraction for building DOM in reflex-dom. This module defines
+-- 'DomBuilder', the typeclass that all DOM-constructing code is written against,
+-- along with the configuration and result types for elements, inputs, and events.
+--
+-- == DOM Spaces
+--
+-- reflex-dom supports three rendering backends, selected by the phantom type
+-- in 'DomBuilderSpace':
+--
+-- * 'StaticDomSpace' — server-side rendering to 'ByteString'. All events are
+--   'never', all raw elements are @()@, no JavaScript context available.
+--   Used by Lamarckian static page generation and 'renderStatic'.
+--
+-- * 'GhcjsDomSpace' — live GHCJS DOM. Raw elements are real @DOM.Element@
+--   values, events fire from @addEventListener@ callbacks, full 'MonadJSM'
+--   access. Used by the Obelisk frontend and any GHCJS-compiled app.
+--
+-- * 'HydrationDomSpace' — hybrid SSR reattach. Reuses server-rendered DOM
+--   nodes, then switches to live mode after a switchover event.
+--
+-- == Constraint Design
+--
+-- 'DomBuilder' intentionally has a minimal superclass set:
+--
+-- @
+-- (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable t m)
+-- @
+--
+-- It does /not/ imply 'MonadHold', 'PostBuild', 'MonadJSM', 'PerformEvent',
+-- or 'TriggerEvent'. Add those constraints explicitly when needed:
+--
+-- @
+-- \-\- Just build DOM (static-compatible):
+-- myWidget :: DomBuilder t m => m ()
+--
+-- \-\- Dynamic attributes (still static-compatible, attrs just won\'t change):
+-- myWidget :: (DomBuilder t m, PostBuild t m) => m ()
+--
+-- \-\- State management (still static-compatible, state is constant in static):
+-- myWidget :: (DomBuilder t m, PostBuild t m, MonadHold t m) => m ()
+--
+-- \-\- Full interactive widget (static-compatible):
+-- myWidget :: (DomBuilder t m, PostBuild t m, MonadHold t m, MonadFix m) => m ()
+-- @
+--
+-- == Extracting Events
+--
+-- Use the primed variant of element builders (e.g. 'Reflex.Dom.Widget.Basic.elAttr\'')
+-- to get an 'Element' handle, then 'domEvent' to extract specific events:
+--
+-- @
+-- (btnEl, _) <- elAttr\' \"button\" (\"class\" =: \"btn\") $ text \"Click\"
+-- let clickEvt = domEvent Click btnEl   -- Event t ()
+-- let keyEvt   = domEvent Keydown btnEl -- Event t Word
+-- @
 module Reflex.Dom.Builder.Class
        ( module Reflex.Dom.Builder.Class
        , module Reflex.Dom.Builder.Class.Events
@@ -65,21 +123,82 @@ import Data.Type.Coercion
 import GHCJS.DOM.Types (JSM)
 import qualified GHCJS.DOM.Types as DOM
 
+-- | Abstraction over the rendering target. Each DOM space defines what
+-- raw node types look like and how events are represented.
+--
+-- Three spaces exist:
+--
+-- [@'StaticDomSpace'@] All @Raw*@ types are @()@. 'EventSpec' is trivial (no events fire).
+--   Defined in "Reflex.Dom.Builder.Static".
+-- [@'GhcjsDomSpace'@] @Raw*@ types are real jsaddle-dom types (e.g. @DOM.Element@).
+--   Events use 'GhcjsEventSpec' backed by @addEventListener@.
+--   Defined in "Reflex.Dom.Builder.Immediate".
+-- [@'HydrationDomSpace'@] @RawDocument@ is @DOM.Document@ but element types are @()@
+--   until hydration switchover. Defined in "Reflex.Dom.Builder.Immediate".
+--
+-- @since 0.8.0.0
 class Default (EventSpec d EventResult) => DomSpace d where
+  -- | How events are specified for this space. 'StaticDomSpace' uses a no-op
+  -- spec; 'GhcjsDomSpace' uses 'GhcjsEventSpec' with JS callbacks.
   type EventSpec d :: (EventTag -> *) -> *
+  -- | The document handle type. @()@ in static, @DOM.Document@ in GHCJS.
   type RawDocument d :: *
+  -- | Raw text node. @()@ in static, @DOM.Text@ in GHCJS.
   type RawTextNode d :: *
+  -- | Raw comment node. @()@ in static, @DOM.Comment@ in GHCJS.
   type RawCommentNode d :: *
+  -- | Raw element node. @()@ in static, @DOM.Element@ in GHCJS.
+  -- Available via '_element_raw' on the 'Element' returned by primed builders.
   type RawElement d :: *
+  -- | Raw input element. @()@ in static, @DOM.HTMLInputElement@ in GHCJS.
   type RawInputElement d :: *
+  -- | Raw textarea element. @()@ in static, @DOM.HTMLTextAreaElement@ in GHCJS.
   type RawTextAreaElement d :: *
+  -- | Raw select element. @()@ in static, @DOM.HTMLSelectElement@ in GHCJS.
   type RawSelectElement d :: *
+  -- | Add event flags (stop propagation, prevent default) to an event spec.
   addEventSpecFlags :: proxy d -> EventName en -> (Maybe (er en) -> EventFlags) -> EventSpec d er -> EventSpec d er
 
 -- | @'DomBuilder' t m@ indicates that @m@ is a 'Monad' capable of building
--- dynamic DOM in the 'Reflex' timeline @t@
+-- dynamic DOM in the 'Reflex' timeline @t@.
+--
+-- This is the central typeclass of reflex-dom. All element-building functions
+-- ('Reflex.Dom.Widget.Basic.el', 'Reflex.Dom.Widget.Basic.elAttr', etc.) are
+-- implemented in terms of 'element'.
+--
+-- == Superclasses
+--
+-- * 'Monad' @m@
+-- * 'Reflex' @t@ — the FRP timeline
+-- * 'DomSpace' @(DomBuilderSpace m)@ — which rendering backend
+-- * 'NotReady' @t m@ — widget readiness tracking
+-- * 'Adjustable' @t m@ — dynamic widget replacement ('runWithReplace')
+--
+-- Notably absent: 'MonadHold', 'PostBuild', 'MonadJSM', 'PerformEvent'.
+-- These are added as separate constraints where needed, keeping the base
+-- interface compatible with all three DOM spaces.
+--
+-- == Methods
+--
+-- Most user code should use the convenience functions in
+-- "Reflex.Dom.Widget.Basic" rather than calling these methods directly.
+-- The methods here are the low-level primitives that those functions wrap.
+--
+-- == Instances
+--
+-- Instances exist for 'StaticDomBuilderT' (from "Reflex.Dom.Builder.Static"),
+-- 'ImmediateDomBuilderT' and 'HydrationDomBuilderT' (from
+-- "Reflex.Dom.Builder.Immediate"), and all standard monad transformers
+-- ('ReaderT', 'PostBuildT', 'RequesterT', 'EventWriterT', etc.).
+--
+-- @since 0.8.0.0
 class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable t m) => DomBuilder t m | m -> t where
+  -- | Which 'DomSpace' this builder targets. Determines the concrete types
+  -- of raw elements, events, and document handles.
   type DomBuilderSpace m :: *
+  -- | Create a text node. In static context, serializes the text content.
+  -- In GHCJS, calls @document.createTextNode@. The optional 'Event' in the
+  -- config allows updating the text content over time (only fires in GHCJS).
   textNode :: TextNodeConfig t -> m (TextNode (DomBuilderSpace m) t)
   default textNode :: ( MonadTrans f
                       , m ~ f m'
@@ -89,6 +208,8 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
                    => TextNodeConfig t -> m (TextNode (DomBuilderSpace m) t)
   textNode = lift . textNode
   {-# INLINABLE textNode #-}
+  -- | Create an HTML comment node. Used internally for marking dynamic
+  -- replacement boundaries (e.g. 'runWithReplace' insertion points).
   commentNode :: CommentNodeConfig t -> m (CommentNode (DomBuilderSpace m) t)
   default commentNode :: ( MonadTrans f
                       , m ~ f m'
@@ -98,6 +219,24 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
                    => CommentNodeConfig t -> m (CommentNode (DomBuilderSpace m) t)
   commentNode = lift . commentNode
   {-# INLINABLE commentNode #-}
+  -- | Create a DOM element with the given tag name, configuration, and children.
+  -- Returns the 'Element' handle (for event queries via 'domEvent') and the
+  -- child result. This is the primitive that 'Reflex.Dom.Widget.Basic.el',
+  -- 'Reflex.Dom.Widget.Basic.elAttr', etc. are built on.
+  --
+  -- In 'StaticDomSpace', serializes @\<tag attrs\>children\<\/tag\>@ as bytes.
+  -- In 'GhcjsDomSpace', calls @document.createElement@, sets attributes, and
+  -- appends to the parent node.
+  --
+  -- Most user code should prefer the convenience wrappers:
+  --
+  -- @
+  -- \-\- Instead of this:
+  -- (el_, result) <- element \"div\" (def & initialAttributes .~ (\"class\" =: \"box\")) $ text \"Hi\"
+  --
+  -- \-\- Write this:
+  -- (el_, result) <- elAttr\' \"div\" (\"class\" =: \"box\") $ text \"Hi\"
+  -- @
   element :: Text -> ElementConfig er t (DomBuilderSpace m) -> m a -> m (Element er (DomBuilderSpace m) t, a)
   default element :: ( MonadTransControl f
                      , StT f a ~ a
@@ -108,6 +247,26 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
                   => Text -> ElementConfig er t (DomBuilderSpace m) -> m a -> m (Element er (DomBuilderSpace m) t, a)
   element t cfg child = liftWith $ \run -> element t cfg $ run child
   {-# INLINABLE element #-}
+  -- | Create an @\<input\>@ element. Returns an 'InputElement' with:
+  --
+  -- * '_inputElement_value' — @Dynamic t Text@ of the current value
+  -- * '_inputElement_checked' — @Dynamic t Bool@ of the checked state
+  -- * '_inputElement_input' — @Event t Text@ firing on user input
+  -- * '_inputElement_checkedChange' — @Event t Bool@ firing on check change
+  -- * '_inputElement_hasFocus' — @Dynamic t Bool@ of focus state
+  --
+  -- In 'StaticDomSpace', the value is @constDyn initialValue@ and all
+  -- events are 'never'. In 'GhcjsDomSpace', values are two-way bound
+  -- to the live DOM element.
+  --
+  -- @
+  -- inp <- inputElement $ def
+  --   & inputElementConfig_initialValue .~ \"\"
+  --   & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
+  --       (\"placeholder\" =: \"Enter name\" \<\> \"type\" =: \"text\")
+  -- let valueDyn = _inputElement_value inp   -- Dynamic t Text
+  -- let inputEvt = _inputElement_input inp   -- Event t Text
+  -- @
   inputElement :: InputElementConfig er t (DomBuilderSpace m) -> m (InputElement er (DomBuilderSpace m) t)
   default inputElement :: ( MonadTransControl f
                           , m ~ f m'
@@ -117,6 +276,7 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
                        => InputElementConfig er t (DomBuilderSpace m) -> m (InputElement er (DomBuilderSpace m) t)
   inputElement = lift . inputElement
   {-# INLINABLE inputElement #-}
+  -- | Create a @\<textarea\>@ element. Like 'inputElement' but for multi-line text.
   textAreaElement :: TextAreaElementConfig er t (DomBuilderSpace m) -> m (TextAreaElement er (DomBuilderSpace m) t)
   default textAreaElement :: ( MonadTransControl f
                              , m ~ f m'
@@ -126,6 +286,8 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
                           => TextAreaElementConfig er t (DomBuilderSpace m) -> m (TextAreaElement er (DomBuilderSpace m) t)
   textAreaElement = lift . textAreaElement
   {-# INLINABLE textAreaElement #-}
+  -- | Create a @\<select\>@ element. The child @m a@ should contain @\<option\>@
+  -- elements. Returns a 'SelectElement' with the current selection value.
   selectElement :: SelectElementConfig er t (DomBuilderSpace m) -> m a -> m (SelectElement er (DomBuilderSpace m) t, a)
   default selectElement :: ( MonadTransControl f
                            , StT f a ~ a
@@ -137,6 +299,9 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
   selectElement cfg child = do
     liftWith $ \run -> selectElement cfg $ run child
   {-# INLINABLE selectElement #-}
+  -- | Insert a pre-existing raw DOM element into the builder's current
+  -- position. Only meaningful in 'GhcjsDomSpace' where raw elements are
+  -- real @DOM.Element@ values.
   placeRawElement :: RawElement (DomBuilderSpace m) -> m ()
   default placeRawElement :: ( MonadTrans f
                              , m ~ f m'
@@ -146,6 +311,9 @@ class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable
                           => RawElement (DomBuilderSpace m) -> m ()
   placeRawElement = lift . placeRawElement
   {-# INLINABLE placeRawElement #-}
+  -- | Wrap a pre-existing raw DOM element, attaching event handlers and
+  -- producing an 'Element' handle. Useful for integrating with elements
+  -- created outside of reflex-dom (e.g. from a JS library).
   wrapRawElement :: RawElement (DomBuilderSpace m) -> RawElementConfig er t (DomBuilderSpace m) -> m (Element er (DomBuilderSpace m) t)
   default wrapRawElement :: ( MonadTrans f
                             , m ~ f m'
@@ -218,10 +386,11 @@ mapKeysToAttributeName = Map.mapKeysMonotonic (AttributeName Nothing)
 instance IsString AttributeName where
   fromString = AttributeName Nothing . fromString
 
+-- | Controls whether a DOM event continues propagating up the tree.
 data Propagation
-   = Propagation_Continue
-   | Propagation_Stop
-   | Propagation_StopImmediate
+   = Propagation_Continue       -- ^ Allow normal event propagation.
+   | Propagation_Stop           -- ^ Call @event.stopPropagation()@.
+   | Propagation_StopImmediate  -- ^ Call @event.stopImmediatePropagation()@.
    deriving (Show, Read, Eq, Ord)
 
 instance Semigroup Propagation where
@@ -234,9 +403,11 @@ instance Monoid Propagation where
   {-# INLINABLE mappend #-}
   mappend = (<>)
 
-data EventFlags = EventFlags --TODO: Monoid; ways of building each flag
-  { _eventFlags_propagation :: Propagation
-  , _eventFlags_preventDefault :: Bool
+-- | Flags that modify DOM event behavior. Use 'preventDefault' and
+-- 'stopPropagation' as convenient constructors. Combine with @('<>')@.
+data EventFlags = EventFlags
+  { _eventFlags_propagation :: Propagation   -- ^ How propagation is handled.
+  , _eventFlags_preventDefault :: Bool       -- ^ Whether to call @event.preventDefault()@.
   }
 
 instance Semigroup EventFlags where
@@ -255,11 +426,20 @@ preventDefault = mempty { _eventFlags_preventDefault = True }
 stopPropagation :: EventFlags
 stopPropagation = mempty { _eventFlags_propagation = Propagation_Stop }
 
+-- | Configuration for creating a DOM element via 'element'.
+--
+-- Use 'def' for defaults (no namespace, no attributes, no modifications,
+-- default event spec). Lenses are provided for all fields.
 data ElementConfig er t s
    = ElementConfig { _elementConfig_namespace :: Maybe Namespace
+                     -- ^ Optional XML namespace (e.g. @Just \"http:\/\/www.w3.org\/2000\/svg\"@ for SVG).
                    , _elementConfig_initialAttributes :: Map AttributeName Text
+                     -- ^ Attributes set at creation time.
                    , _elementConfig_modifyAttributes :: Maybe (Event t (Map AttributeName (Maybe Text)))
+                     -- ^ Dynamic attribute patches. @Just v@ sets\/updates; @Nothing@ removes.
+                     -- Only fires in GHCJS; in static rendering the initial attributes are all that matter.
                    , _elementConfig_eventSpec :: EventSpec s er
+                     -- ^ Event specification for this element.
                    }
 
 #ifndef USE_TEMPLATE_HASKELL
@@ -278,9 +458,25 @@ elementConfig_eventSpec f (ElementConfig a b c d) = (\d' -> ElementConfig a b c 
 {-# INLINE elementConfig_eventSpec #-}
 #endif
 
+-- | A handle to a created DOM element. Returned by the primed variants of
+-- element builders (e.g. 'Reflex.Dom.Widget.Basic.el\'', 'Reflex.Dom.Widget.Basic.elAttr\'').
+--
+-- Use 'domEvent' to extract specific events:
+--
+-- @
+-- (e, _) <- el\' \"button\" $ text \"Click\"
+-- let click = domEvent Click e      -- Event t ()
+-- let keys  = domEvent Keydown e    -- Event t Word
+-- let mouse = domEvent Mousemove e  -- Event t (Int, Int)
+-- @
+--
+-- Access the raw DOM element (only useful in 'GhcjsDomSpace') via '_element_raw'.
 data Element er d t
-   = Element { _element_events :: EventSelector t (WrapArg er EventName) --TODO: EventSelector should have two arguments
+   = Element { _element_events :: EventSelector t (WrapArg er EventName)
+               -- ^ Fan of all possible events on this element. Use 'domEvent' to select one.
              , _element_raw :: RawElement d
+               -- ^ The underlying raw DOM element. @()@ in 'StaticDomSpace',
+               -- @DOM.Element@ in 'GhcjsDomSpace'.
              }
 
 data InputElementConfig er t s
@@ -640,6 +836,24 @@ instance (DomBuilder t m, MonadFix m, MonadHold t m, Group q, Query q, Commutati
 
 -- * Convenience functions
 
+-- | Extract a specific event from a DOM element, input, or text area.
+--
+-- The result type depends on the 'EventName' — see 'EventResultType' for the
+-- complete mapping. Common examples:
+--
+-- @
+-- (e, _) <- el\' \"div\" $ text \"Hello\"
+-- let click   = domEvent Click e      -- Event t ()
+-- let keydown = domEvent Keydown e    -- Event t Word
+-- let mouse   = domEvent Mousemove e  -- Event t (Int, Int)
+-- @
+--
+-- Works on 'Element', 'InputElement', and 'TextAreaElement':
+--
+-- @
+-- inp <- inputElement def
+-- let inputKeypress = domEvent Keypress inp  -- Event t Word
+-- @
 class HasDomEvent t target eventName | target -> t where
   type DomEventType target eventName :: *
   domEvent :: EventName eventName -> target -> Event t (DomEventType target eventName)
@@ -728,6 +942,19 @@ deriving instance DomRenderHook t m => DomRenderHook t (QueryT t q m)
 liftElementConfig :: ElementConfig er t s -> ElementConfig er t s
 liftElementConfig = id
 
+-- | Provides access to the raw document object for the current 'DomSpace'.
+--
+-- In 'GhcjsDomSpace' (from "Reflex.Dom.Builder.Immediate"), @askDocument@
+-- returns a real @DOM.Document@ that you can use for direct DOM operations
+-- (e.g. @createElement@, @querySelector@).
+--
+-- In 'StaticDomSpace' (from "Reflex.Dom.Builder.Static"), @askDocument@
+-- returns @()@ — there is no document.
+--
+-- This class is primarily used internally by the builder implementations.
+-- Application code typically uses 'DomBuilder' methods instead.
+--
+-- @since 0.8.0.0
 class Monad m => HasDocument m where
   askDocument :: m (RawDocument (DomBuilderSpace m))
   default askDocument

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Class/Events.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Class/Events.hs
@@ -6,6 +6,24 @@
 {-# LANGUAGE TemplateHaskell #-}
 #endif
 {-# LANGUAGE TypeFamilies #-}
+-- |
+-- Module: Reflex.Dom.Builder.Class.Events
+--
+-- Type-level enumeration of DOM events. Every standard DOM event has a
+-- corresponding 'EventTag' promoted constructor and a matching 'EventName'
+-- GADT value.
+--
+-- These are used throughout reflex-dom to provide type-safe event selection:
+--
+-- @
+-- domEvent Click myElement   :: Event t ()
+-- domEvent Keypress myElement :: Event t Word
+-- domEvent Input myElement    :: Event t Text
+-- @
+--
+-- The result type for each event is determined by the 'EventResult' type
+-- family in "Reflex.Dom.Builder.Class", which maps @ClickTag@ to @()@,
+-- @KeypressTag@ to @Word@, @InputTag@ to @Text@, etc.
 module Reflex.Dom.Builder.Class.Events where
 
 #ifdef USE_TEMPLATE_HASKELL
@@ -17,6 +35,8 @@ import Data.GADT.Compare
 #endif
 import Data.Text (Text)
 
+-- | Enumeration of all supported DOM event types. Promoted to the kind level
+-- via DataKinds and used as the index for 'EventName' and 'EventResult'.
 data EventTag
    = AbortTag
    | BlurTag
@@ -65,6 +85,16 @@ data EventTag
    | TouchendTag
    | TouchcancelTag
 
+-- | Singleton GADT for event names. Each constructor corresponds to an
+-- 'EventTag' and carries the tag at the type level.
+--
+-- Use these constructors with 'domEvent' to select specific event streams:
+--
+-- @
+-- clicks    = domEvent Click el      -- Event t ()
+-- keypresses = domEvent Keypress el  -- Event t Word
+-- scrolls   = domEvent Scroll el     -- Event t Int
+-- @
 data EventName :: EventTag -> * where
   Abort :: EventName 'AbortTag
   Blur :: EventName 'BlurTag
@@ -113,8 +143,45 @@ data EventName :: EventTag -> * where
   Touchend :: EventName 'TouchendTag
   Touchcancel :: EventName 'TouchcancelTag
 
+-- | Wrapper newtype that pairs an 'EventTag' with its result value.
+-- Used as the @er@ parameter throughout the 'DomBuilder' API.
+--
+-- When you write @domEvent Click el@, reflex-dom internally selects from
+-- an @EventSelector (WrapArg EventResult)@ and unwraps the 'EventResult'
+-- to give you the raw 'EventResultType'.
+--
+-- @since 0.8.0.0
 newtype EventResult en = EventResult { unEventResult :: EventResultType en }
 
+-- | Maps each 'EventTag' to the Haskell type of data extracted from that
+-- DOM event. This is what determines the type of @domEvent SomeEvent el@.
+--
+-- == Quick reference
+--
+-- @
+-- domEvent Click el      :: Event t ()           -- ClickTag → ()
+-- domEvent Dblclick el   :: Event t (Int, Int)   -- mouse coordinates
+-- domEvent Keypress el   :: Event t Word         -- key code
+-- domEvent Keydown el    :: Event t Word         -- key code
+-- domEvent Keyup el      :: Event t Word         -- key code
+-- domEvent Scroll el     :: Event t Double       -- scroll position
+-- domEvent Mousemove el  :: Event t (Int, Int)   -- mouse coordinates
+-- domEvent Mousedown el  :: Event t (Int, Int)   -- mouse coordinates
+-- domEvent Mouseup el    :: Event t (Int, Int)   -- mouse coordinates
+-- domEvent Input el      :: Event t ()           -- (use _inputElement_value for text)
+-- domEvent Change el     :: Event t ()
+-- domEvent Focus el      :: Event t ()
+-- domEvent Blur el       :: Event t ()
+-- domEvent Paste el      :: Event t (Maybe Text) -- clipboard text
+-- domEvent Touchstart el :: Event t TouchEventResult
+-- domEvent Wheel el      :: Event t WheelEventResult
+-- @
+--
+-- Most events return @()@ — the event firing IS the information. For events
+-- with payload (keyboard, mouse, touch, wheel, paste), the result carries
+-- the extracted data.
+--
+-- @since 0.8.0.0
 type family EventResultType (en :: EventTag) :: * where
   EventResultType 'ClickTag = ()
   EventResultType 'DblclickTag = (Int, Int)
@@ -163,9 +230,12 @@ type family EventResultType (en :: EventTag) :: * where
   EventResultType 'TouchcancelTag = TouchEventResult
   EventResultType 'WheelTag = WheelEventResult
 
+-- | How to interpret the delta values in a 'WheelEventResult'.
 data DeltaMode = DeltaPixel | DeltaLine | DeltaPage
   deriving (Show, Read, Eq, Ord, Bounded, Enum)
 
+-- | Data extracted from a @wheel@ DOM event. Contains scroll delta values
+-- along all three axes and the unit of measurement.
 data WheelEventResult = WheelEventResult
   { _wheelEventResult_deltaX :: Double
   , _wheelEventResult_deltaY :: Double
@@ -173,6 +243,9 @@ data WheelEventResult = WheelEventResult
   , _wheelEventResult_deltaMode :: DeltaMode
   } deriving (Show, Read, Eq, Ord)
 
+-- | Data extracted from a touch DOM event. Contains modifier key states and
+-- three lists of 'TouchResult': changed touches, target touches, and all
+-- active touches.
 data TouchEventResult = TouchEventResult
   { _touchEventResult_altKey :: Bool
   , _touchEventResult_changedTouches :: [TouchResult]

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Immediate.hs
@@ -228,6 +228,14 @@ instance MonadJSM m => MonadJSM (DomRenderHookT t m) where
   liftJSM' = lift . liftJSM'
 #endif
 
+-- | Environment for 'HydrationDomBuilderT'. Carries references to the DOM
+-- document, parent node, hydration state, and synchronization machinery.
+--
+-- During hydration, the builder walks the pre-existing DOM tree (produced by
+-- 'Reflex.Dom.Builder.Static.renderStatic') and attaches event handlers to
+-- existing nodes rather than creating new ones. After the switchover event
+-- fires, it transitions to immediate mode where new DOM nodes are created
+-- and appended directly.
 data HydrationDomBuilderEnv t m = HydrationDomBuilderEnv
   { _hydrationDomBuilderEnv_document :: {-# UNPACK #-} !Document
   -- ^ Reference to the document
@@ -244,11 +252,41 @@ data HydrationDomBuilderEnv t m = HydrationDomBuilderEnv
   , _hydrationDomBuilderEnv_delayed :: {-# UNPACK #-} !(IORef (HydrationRunnerT t m ()))
   }
 
--- | A monad for DomBuilder which just gets the results of children and pushes
--- work into an action that is delayed until after postBuild (to match the
--- static builder). The action runs in 'HydrationRunnerT', which performs the
--- DOM takeover and sets up the events, after which point this monad will
--- continue in the vein of 'ImmediateDomBuilderT'.
+-- | The main client-side 'DomBuilder' monad transformer, parameterized by a
+-- 'DomSpace' @s@ which determines whether it operates in hydration mode
+-- or immediate mode.
+--
+-- == Two modes of operation
+--
+-- * @HydrationDomBuilderT 'HydrationDomSpace' t m@ — __hydration mode__:
+--   walks pre-existing DOM nodes (from server-side rendering) and attaches
+--   event handlers without creating new elements. After the switchover event,
+--   transitions to creating nodes normally.
+--
+-- * @HydrationDomBuilderT 'GhcjsDomSpace' t m@ — __immediate mode__
+--   (aliased as 'ImmediateDomBuilderT'): creates and appends real DOM nodes
+--   on every call to 'element', 'textNode', etc.
+--
+-- == Monad stack
+--
+-- Internally, this is a @ReaderT ('HydrationDomBuilderEnv' t m) ('DomRenderHookT' t m)@.
+-- The 'DomRenderHookT' layer manages deferred DOM actions (for safe batching
+-- of DOM mutations) and event trigger channels.
+--
+-- == Instances provided
+--
+-- 'DomBuilder', 'PostBuild', 'TriggerEvent', 'PerformEvent', 'MonadHold',
+-- 'MonadSample', 'MonadJSM', 'Adjustable', 'NotReady', 'HasDocument',
+-- 'Requester'.
+--
+-- When @s ~ GhcjsDomSpace@, 'Element' values contain real DOM references
+-- and 'domEvent' returns live events wired to actual browser event listeners.
+--
+-- The server-side counterpart is 'StaticDomBuilderT' (from
+-- "Reflex.Dom.Builder.Static"). For prerender-based splitting between
+-- server and client code, see "Reflex.Dom.Prerender".
+--
+-- @since 0.8.0.0
 newtype HydrationDomBuilderT s t m a = HydrationDomBuilderT { unHydrationDomBuilderT :: ReaderT (HydrationDomBuilderEnv t m) (DomRenderHookT t m) a }
   deriving (Functor, Applicative, Monad, MonadFix, MonadIO, MonadException
 #if MIN_VERSION_base(4,9,1)
@@ -268,8 +306,22 @@ instance (Reflex t, MonadFix m) => DomRenderHook t (HydrationDomBuilderT s t m) 
   requestDomAction = HydrationDomBuilderT . lift . requestDomAction
   requestDomAction_ = HydrationDomBuilderT . lift . requestDomAction_
 
--- | The monad which performs the delayed actions to reuse prerendered nodes and set up events.
--- State contains reference to the previous node sibling, if any, and the reader contains reference to the parent node.
+-- | The monad that performs the actual DOM hydration walk at switchover time.
+--
+-- When the page loads with server-rendered HTML, 'HydrationDomBuilderT'
+-- accumulates deferred actions. When the switchover event fires, those actions
+-- run inside 'HydrationRunnerT', which walks the existing DOM tree:
+--
+-- * The 'ReaderT Node' carries the current parent node
+-- * The 'StateT HydrationState' tracks the most recently visited sibling
+--   (so the runner can advance through child nodes sequentially)
+-- * If the DOM doesn't match expectations (e.g. a text node where an element
+--   was expected), the runner sets @_hydrationState_failed@ and prints a
+--   warning
+--
+-- After the hydration walk completes, any remaining DOM nodes after the last
+-- visited sibling are removed (via 'removeSubsequentNodes'). This cleans up
+-- server-rendered content that the client doesn't expect.
 newtype HydrationRunnerT t m a = HydrationRunnerT { unHydrationRunnerT :: StateT HydrationState (ReaderT Node (DomRenderHookT t m)) a }
   deriving (Functor, Applicative, Monad, MonadFix, MonadIO, MonadException
 #if MIN_VERSION_base(4,9,1)
@@ -432,11 +484,22 @@ append n = do
   -> HydrationDomBuilderT s Spider HydrationM ()
   #-}
 
+-- | Tracks whether the builder is still walking pre-rendered DOM nodes
+-- or has switched to creating them from scratch.
+--
+-- During 'HydrationMode_Hydrating', 'HydrationDomBuilderT' expects to find
+-- matching DOM nodes already present (produced by the static renderer).
+-- If the actual DOM doesn't match what the builder expects, hydration will
+-- fail with a warning.
+--
+-- After the switchover event fires, the mode changes to
+-- 'HydrationMode_Immediate' and all subsequent widget builds create new DOM
+-- nodes normally.
 data HydrationMode
   = HydrationMode_Hydrating
-  -- ^ The time from initial load to parity with static builder
+  -- ^ Walking pre-existing server-rendered DOM nodes, attaching event handlers
   | HydrationMode_Immediate
-  -- ^ After hydration
+  -- ^ Creating and appending new DOM nodes (normal operation)
   deriving (Eq, Ord, Show)
 
 {-# INLINABLE getPreviousNode #-}
@@ -517,14 +580,29 @@ extractUpTo df s e = liftJSM $ do
   void $ call f f (df, s, e)
 #endif
 
+-- | Constraint bundle for monads that can run 'HydrationDomBuilderT'.
+--
+-- Compared to 'SupportsStaticDomBuilder', this additionally requires
+-- 'MonadJSM' (and @MonadJSM (Performable m)@) because the hydration and
+-- immediate DOM builders need access to the JavaScript context for DOM
+-- manipulation and event wiring.
+--
+-- This is satisfied by the concrete monad stack used by @mainWidget@ and
+-- friends: 'PerformEventT' over 'DomHost' with a JSM context.
 type SupportsHydrationDomBuilder t m = (Reflex t, MonadJSM m, MonadHold t m, MonadFix m, MonadReflexCreateTrigger t m, MonadRef m, Ref m ~ Ref JSM, Adjustable t m, PrimMonad m, PerformEvent t m, MonadJSM (Performable m))
 
+-- | Collect all DOM nodes between @start@ (inclusive) and @end@ (exclusive)
+-- into a 'DocumentFragment', removing them from the live DOM. Used internally
+-- by the 'Adjustable' instance to extract widget content regions for
+-- replacement or reordering.
 {-# INLINABLE collectUpTo #-}
 collectUpTo :: (MonadJSM m, IsNode start, IsNode end) => start -> end -> m DOM.DocumentFragment
 collectUpTo s e = do
   currentParent <- getParentNodeUnchecked e -- May be different than it was at initial construction, e.g., because the parent may have dumped us in from a DocumentFragment
   collectUpToGivenParent currentParent s e
 
+-- | Like 'collectUpTo' but takes an explicit parent node, avoiding a
+-- 'getParentNodeUnchecked' call. Useful when the parent is already known.
 {-# INLINABLE collectUpToGivenParent #-}
 collectUpToGivenParent :: (MonadJSM m, IsNode parent, IsNode start, IsNode end) => parent -> start -> end -> m DOM.DocumentFragment
 collectUpToGivenParent currentParent s e = do
@@ -635,6 +713,26 @@ newtype GhcjsDomHandler1 a b = GhcjsDomHandler1 { unGhcjsDomHandler1 :: forall (
 
 newtype GhcjsDomEvent en = GhcjsDomEvent { unGhcjsDomEvent :: EventType en }
 
+-- | The 'DomSpace' for live client-side rendering via GHCJS (or JSaddle).
+--
+-- All associated types resolve to real DOM objects:
+--
+-- * @RawDocument GhcjsDomSpace = Document@
+-- * @RawElement GhcjsDomSpace = Element@
+-- * @RawTextNode GhcjsDomSpace = Text@
+-- * @RawInputElement GhcjsDomSpace = HTMLInputElement@
+-- * @RawTextAreaElement GhcjsDomSpace = HTMLTextAreaElement@
+-- * @RawSelectElement GhcjsDomSpace = HTMLSelectElement@
+--
+-- This is what 'ImmediateDomBuilderT' uses. 'Element' values from this space
+-- carry real DOM node references, so you can pass @_element_raw@ to JavaScript
+-- FFI, read element dimensions, attach custom event listeners, etc.
+--
+-- Compare with 'StaticDomSpace' (all @()@, from "Reflex.Dom.Builder.Static")
+-- and 'HydrationDomSpace' (also @()@ for raw nodes, but uses real event
+-- processing).
+--
+-- @since 0.8.0.0
 data GhcjsDomSpace
 
 instance DomSpace GhcjsDomSpace where
@@ -666,6 +764,22 @@ data Pair1 (f :: k -> *) (g :: k -> *) (a :: k) = Pair1 (f a) (g a)
 
 data Maybe1 f a = Nothing1 | Just1 (f a)
 
+-- | Specification for how DOM events are processed in 'GhcjsDomSpace' and
+-- 'HydrationDomSpace'.
+--
+-- The @er@ parameter is typically 'EventResult', which maps each
+-- 'EventTag' to its result type (e.g. @ClickTag@ → @()@,
+-- @InputTag@ → @Text@, @KeypressTag@ → @Word@).
+--
+-- * @_ghcjsEventSpec_filters@ — per-event-name filters that can inspect the
+--   raw DOM event and return 'EventFlags' (preventDefault, stopPropagation)
+--   plus an optional result. These are installed by 'addEventSpecFlags' in
+--   the 'DomSpace' instance.
+--
+-- * @_ghcjsEventSpec_handler@ — the default handler used for events without
+--   a specific filter. Delegates to 'defaultDomEventHandler' which extracts
+--   the appropriate value from the DOM event (e.g. mouse coordinates for
+--   click, key code for keypress).
 data GhcjsEventSpec er = GhcjsEventSpec
   { _ghcjsEventSpec_filters :: DMap EventName (GhcjsEventFilter er)
   , _ghcjsEventSpec_handler :: GhcjsEventHandler er
@@ -1416,6 +1530,30 @@ instance SupportsHydrationDomBuilder t m => NotReady t (HydrationDomBuilderT s t
     unreadyChildren <- askUnreadyChildren
     liftIO $ modifyIORef' unreadyChildren succ
 
+-- | The 'DomSpace' used during hydration — the process of taking over
+-- server-rendered HTML and attaching event handlers to the existing DOM.
+--
+-- Raw element types are @()@ (just like 'StaticDomSpace') because during
+-- hydration we don't hold references to individual elements in the monad's
+-- return values. However, the event processing infrastructure is real
+-- ('GhcjsEventSpec'), so event handlers are correctly wired up during the
+-- hydration walk.
+--
+-- After hydration completes, 'HydrationDomBuilderT' switches to
+-- 'HydrationMode_Immediate' internally, but the @s@ type parameter remains
+-- 'HydrationDomSpace' — only the runtime behavior changes.
+--
+-- Compare with 'StaticDomSpace' (from "Reflex.Dom.Builder.Static", pure
+-- server-side rendering with no event processing) and 'GhcjsDomSpace'
+-- (full live DOM with real element references).
+--
+-- @
+-- RawDocument HydrationDomSpace = Document  -- real document reference
+-- RawElement HydrationDomSpace  = ()        -- no element references
+-- RawTextNode HydrationDomSpace = ()        -- no text node references
+-- @
+--
+-- @since 0.8.0.0
 data HydrationDomSpace
 
 instance DomSpace HydrationDomSpace where
@@ -1527,6 +1665,29 @@ instance (Reflex t, Monad m, Adjustable t m, MonadHold t m, MonadFix m) => Adjus
   traverseDMapWithKeyWithAdjust f m = DomRenderHookT . traverseDMapWithKeyWithAdjust (\k -> unDomRenderHookT . f k) m
   traverseDMapWithKeyWithAdjustWithMove f m = DomRenderHookT . traverseDMapWithKeyWithAdjustWithMove (\k -> unDomRenderHookT . f k) m
 
+-- | 'Adjustable' instance for client-side DOM building. Powers 'dyn', 'dyn_',
+-- 'widgetHold', 'listWithKey', and all dynamic widget swapping.
+--
+-- == How it works in immediate\/hydration mode
+--
+-- 'runWithReplace' creates a DOM region bounded by two comment sentinel nodes.
+-- The initial widget @a0@ is rendered between them. When the replacement event
+-- @a'@ fires, the region between the sentinels is cleared (all child nodes
+-- removed) and the new widget is rendered in its place.
+--
+-- This is fundamentally different from the static 'Adjustable' instance:
+-- here, DOM nodes are actually created and destroyed. The implementation
+-- tracks \"cohorts\" (generations of content) to handle rapid replacements
+-- and ensure the DOM stays consistent.
+--
+-- During hydration, 'runWithReplace' must match the sentinel comments that
+-- the static renderer emitted. After switchover, it operates like the
+-- immediate builder.
+--
+-- 'traverseDMapWithKeyWithAdjust' (used by @listWithKey@, @simpleList@, etc.)
+-- maintains a live collection of child widgets, each bounded by their own
+-- sentinel nodes. Patches (insertions, deletions, moves) are applied to the
+-- DOM incrementally — only changed children are touched.
 instance (Adjustable t m, MonadJSM m, MonadHold t m, MonadFix m, PrimMonad m, RawDocument (DomBuilderSpace (HydrationDomBuilderT s t m)) ~ Document) => Adjustable t (HydrationDomBuilderT s t m) where
   {-# INLINABLE runWithReplace #-}
   runWithReplace a0 a' = do
@@ -1792,6 +1953,13 @@ traverseIntMapWithKeyWithAdjust' = do
   -> HydrationDomBuilderT HydrationDomSpace DomTimeline HydrationM (IntMap v', Event DomTimeline (PatchIntMap v'))
   #-}
 
+-- | Tracks whether a child widget has finished its initial build. Used by
+-- 'drawChildUpdate' and the 'Adjustable' instance to coordinate when all
+-- children are ready (so the parent can fire its commit action).
+--
+-- * 'ChildReadyState_Ready' — the child is fully rendered
+-- * @ChildReadyState_Unready (Just key)@ — still rendering, identified by @key@
+-- * @ChildReadyState_Unready Nothing@ — still rendering, no key
 data ChildReadyState a
    = ChildReadyState_Ready
    | ChildReadyState_Unready !(Maybe a)
@@ -2077,6 +2245,15 @@ data TraverseChild t m k a = TraverseChild
   , _traverseChild_result :: !a
   } deriving Functor
 
+-- | Render a single child widget within the context of
+-- 'traverseDMapWithKeyWithAdjust' (i.e. list rendering). Creates the child's
+-- DOM region with sentinel nodes, tracks its 'ChildReadyState', and returns
+-- the result wrapped in @TraverseChild@ for incremental patch application.
+--
+-- The @markReady@ callback is invoked when the child finishes rendering, but
+-- only if the child was NOT immediately ready. If the child is ready at
+-- initialization time, the returned 'ChildReadyState' will be
+-- 'ChildReadyState_Ready' and the callback is never called.
 {-# INLINABLE drawChildUpdate #-}
 drawChildUpdate :: (MonadJSM m, Reflex t)
   => HydrationDomBuilderEnv t m
@@ -2166,11 +2343,30 @@ mkHasFocus e = do
     , True <$ Reflex.select (_element_events e) (WrapArg Focus)
     ]
 
+-- | Insert a node immediately before an existing sibling node in the DOM.
+-- Used internally for inserting content at specific positions during
+-- 'Adjustable' patch application.
 insertBefore :: (MonadJSM m, IsNode new, IsNode existing) => new -> existing -> m ()
 insertBefore new existing = do
   p <- getParentNodeUnchecked existing
   Node.insertBefore_ p new (Just existing) -- If there's no parent, that means we've been removed from the DOM; this should not happen if the we're removing ourselves from the performEvent properly
 
+-- | Convenience alias for direct (non-hydrating) client-side DOM building.
+--
+-- @ImmediateDomBuilderT t m ≡ HydrationDomBuilderT GhcjsDomSpace t m@
+--
+-- When you see @Widget x@ from "Reflex.Dom.Main", the outermost transformer
+-- is 'ImmediateDomBuilderT'. This is the concrete monad that actually creates
+-- and appends DOM elements in the browser.
+--
+-- In this mode, 'Element' values carry real @DOM.Element@ references, and
+-- 'domEvent' wires up actual browser event listeners via the 'GhcjsEventSpec'
+-- infrastructure.
+--
+-- The server-side counterpart is 'StaticDomBuilderT' (from
+-- "Reflex.Dom.Builder.Static").
+--
+-- @since 0.8.0.0
 type ImmediateDomBuilderT = HydrationDomBuilderT GhcjsDomSpace
 
 instance PerformEvent t m => PerformEvent t (HydrationDomBuilderT s t m) where
@@ -2219,6 +2415,17 @@ instance MonadAtomicRef m => MonadAtomicRef (HydrationDomBuilderT s t m) where
   {-# INLINABLE atomicModifyRef #-}
   atomicModifyRef r = lift . atomicModifyRef r
 
+-- | Maps each 'EventTag' to its corresponding GHCJS DOM event type.
+--
+-- This type family is used by 'GhcjsDomEvent' and the event handling
+-- infrastructure to determine the correct DOM event type for each event name.
+-- For example, @EventType 'ClickTag = MouseEvent@ ensures that click event
+-- handlers receive a 'MouseEvent', while @EventType 'KeypressTag = KeyboardEvent@
+-- provides keyboard-specific information.
+--
+-- The mapping covers all standard DOM events: mouse events, keyboard events,
+-- focus events, touch events, wheel events, clipboard events, drag events,
+-- and generic UI events.
 type family EventType en where
   EventType 'AbortTag = UIEvent
   EventType 'BlurTag = FocusEvent
@@ -2267,6 +2474,19 @@ type family EventType en where
   EventType 'TouchendTag = TouchEvent
   EventType 'TouchcancelTag = TouchEvent
 
+-- | Default handler for each DOM event type, extracting the appropriate value.
+--
+-- This is what runs when no custom 'GhcjsEventFilter' is installed for an
+-- event. The return value depends on the event tag:
+--
+-- * @Click@, @Dblclick@ → @()@
+-- * @Keypress@, @Keydown@, @Keyup@ → key code ('Word')
+-- * @Scroll@ → scroll position
+-- * @Mousemove@, @Mousedown@, etc. → @(Int, Int)@ coordinates
+-- * @Input@, @Change@ → current element value ('Text')
+-- * @Touchstart@, @Touchmove@, etc. → list of touch points
+-- * @Wheel@ → delta values
+-- * @Paste@ → clipboard 'Text'
 {-# INLINABLE defaultDomEventHandler #-}
 defaultDomEventHandler :: IsElement e => e -> EventName en -> EventM e (EventType en) (Maybe (EventResult en))
 defaultDomEventHandler e evt = fmap (Just . EventResult) $ case evt of
@@ -2575,6 +2795,15 @@ windowOnEventName en e = case en of
   Touchend -> on e Events.touchEnd
   Touchcancel -> on e Events.touchCancel
 
+-- | Subscribe to a DOM event on an element and produce a Reflex 'Event'.
+--
+-- This is the bridge between the DOM event system and Reflex FRP. It registers
+-- a DOM event listener (via the provided subscription function) and routes
+-- the results into a Reflex 'Event' via 'TriggerEvent'.
+--
+-- Typically you don't call this directly — 'domEvent' on 'Element' values
+-- handles it for you. Use this when you need to subscribe to events on
+-- raw DOM nodes obtained via @_element_raw@ or JavaScript FFI.
 {-# INLINABLE wrapDomEvent #-}
 wrapDomEvent :: (TriggerEvent t m, MonadJSM m) => e -> (e -> EventM e event () -> JSM (JSM ())) -> EventM e event a -> m (Event t a)
 wrapDomEvent el elementOnevent getValue = wrapDomEventMaybe el elementOnevent $ fmap Just getValue
@@ -2719,16 +2948,30 @@ instance MonadHold t m => MonadHold t (HydrationDomBuilderT s t m) where
   {-# INLINABLE headE #-}
   headE = lift . headE
 
+-- | Configuration for subscribing to window-level DOM events.
+-- Currently has no configuration options (placeholder for future extension).
 data WindowConfig t = WindowConfig -- No config options yet
 
 instance Default (WindowConfig t) where
   def = WindowConfig
 
+-- | A wrapped browser window with Reflex event subscriptions.
+-- Use @_window_events@ with 'select' to subscribe to window-level events
+-- (e.g. resize, scroll, focus, blur):
+--
+-- @
+-- win <- wrapWindow jsWindow def
+-- let resizeEvt = select (_window_events win) (WrapArg Resize)
+-- @
 data Window t = Window
   { _window_events :: EventSelector t (WrapArg EventResult EventName)
+  -- ^ Event selector for all window-level DOM events
   , _window_raw :: DOM.Window
+  -- ^ The underlying GHCJS Window object
   }
 
+-- | Wrap a raw GHCJS 'DOM.Window' into a Reflex 'Window' with event
+-- subscriptions. Requires 'GhcjsDomSpace' — not available in static rendering.
 wrapWindow :: (MonadJSM m, MonadReflexCreateTrigger t m) => DOM.Window -> WindowConfig t -> HydrationDomBuilderT GhcjsDomSpace t m (Window t)
 wrapWindow wv _ = do
   events <- wrapDomEventsMaybe wv (defaultDomWindowEventHandler wv) windowOnEventName

--- a/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Builder/Static.hs
@@ -13,6 +13,37 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- |
+-- Module: Reflex.Dom.Builder.Static
+--
+-- Server-side rendering of reflex-dom widgets to HTML 'ByteString'. This module
+-- provides 'StaticDomBuilderT', the 'DomBuilder' implementation that serializes
+-- elements as HTML bytes rather than creating live DOM nodes.
+--
+-- == Key Characteristics
+--
+-- * All 'RawElement', 'RawTextNode', etc. types are @()@ — there is no DOM.
+-- * All events are 'never' — no interactivity in static rendering.
+-- * @domEvent Click el@ returns 'never'. @toggle False clickEvt@ returns @constDyn False@.
+-- * 'TriggerEvent' instance returns @(never, \\_ -> pure ())@ — no external events.
+-- * 'MonadJSM' is NOT available — no JavaScript context.
+-- * @\<script\>@ tags are serialized as HTML; the browser will execute them when
+--   it parses the static HTML output.
+--
+-- == Usage
+--
+-- @
+-- (result, htmlBytes) <- renderStatic $ do
+--   el \"div\" $ text \"Hello, world!\"
+-- @
+--
+-- == FRP Code in Static Context
+--
+-- FRP code (Dynamic, Event, etc.) compiles and runs in static context, but is
+-- inert: all Dynamics hold their initial value forever, all Events are 'never',
+-- and 'MonadHold' operations produce constant values. This is by design —
+-- the same polymorphic widget code can run in both static and GHCJS contexts
+-- without branching.
 module Reflex.Dom.Builder.Static where
 
 import Data.IORef (IORef)
@@ -67,6 +98,31 @@ data StaticDomBuilderEnv t = StaticDomBuilderEnv
   , _staticDomBuilderEnv_nextRunWithReplaceKey :: IORef Int
   }
 
+-- | The static rendering monad transformer. Builds up HTML as a 'ByteString'
+-- builder rather than creating live DOM nodes.
+--
+-- Internally, this is a @ReaderT env (StateT [Behavior t Builder] m)@. The
+-- state accumulates HTML fragments in reverse order; 'runStaticDomBuilderT'
+-- reverses and concatenates them into the final output.
+--
+-- This is the 'DomBuilder' instance used by 'renderStatic' and by Obelisk's
+-- server-side rendering. All 'RawElement', 'RawTextNode', etc. types are @()@,
+-- meaning you cannot interact with the DOM at all — but the same polymorphic
+-- widget code that works in GHCJS will compile and run here, producing HTML
+-- output.
+--
+-- The client-side counterparts are 'ImmediateDomBuilderT' (direct DOM
+-- construction) and 'HydrationDomBuilderT' (SSR hydration reattach).
+--
+-- Notable behaviors:
+--
+-- * 'TriggerEvent' returns @(never, \\_ -> pure ())@ — no external event sources
+-- * 'MonadHold' works (values are held) but 'Event's never fire, so held values
+--   never change
+-- * @\<script\>@ tags are serialized into the output; the browser will execute
+--   them when it parses the HTML
+--
+-- @since 0.8.0.0
 newtype StaticDomBuilderT t m a = StaticDomBuilderT
     { unStaticDomBuilderT :: ReaderT (StaticDomBuilderEnv t) (StateT [Behavior t Builder] m) a -- Accumulated Html will be in reversed order
     }
@@ -134,8 +190,30 @@ instance MonadRef m => MonadRef (StaticDomBuilderT t m) where
 instance MonadAtomicRef m => MonadAtomicRef (StaticDomBuilderT t m) where
   atomicModifyRef r = lift . atomicModifyRef r
 
+-- | Constraint bundle for monads that can run 'StaticDomBuilderT'.
+--
+-- This is satisfied by the 'DomHost' monad (via 'runDomHost' / 'renderStatic'),
+-- which provides the Spider timeline, IO, and event infrastructure needed for
+-- sampling 'Behavior's during rendering.
 type SupportsStaticDomBuilder t m = (Reflex t, MonadIO m, MonadHold t m, MonadFix m, PerformEvent t m, MonadReflexCreateTrigger t m, MonadRef m, Ref m ~ Ref IO, Adjustable t m)
 
+-- | The 'DomSpace' for static (server-side) rendering.
+--
+-- All associated types are @()@:
+--
+-- * @RawDocument StaticDomSpace = ()@
+-- * @RawElement StaticDomSpace = ()@
+-- * @RawTextNode StaticDomSpace = ()@
+-- * @RawInputElement StaticDomSpace = ()@
+-- * etc.
+--
+-- This means 'Element' values from static rendering carry no DOM references.
+-- 'domEvent' on a static element always returns 'never'.
+--
+-- Compare with 'GhcjsDomSpace' (real GHCJS DOM objects) and
+-- 'HydrationDomSpace' (hybrid SSR reattach).
+--
+-- @since 0.8.0.0
 data StaticDomSpace
 
 -- | Static documents never produce any events, so this type has no inhabitants
@@ -162,6 +240,27 @@ instance DomSpace StaticDomSpace where
 instance (SupportsStaticDomBuilder t m, Monad m) => HasDocument (StaticDomBuilderT t m) where
   askDocument = pure ()
 
+-- | 'Adjustable' instance for static rendering. This is what powers 'dyn',
+-- 'dyn_', and 'widgetHold' in static context.
+--
+-- == How it works in static rendering
+--
+-- 'runWithReplace' renders the initial widget @a0@ to HTML immediately. When
+-- the replacement event @a'@ fires, the new widget is also rendered — but since
+-- this is static rendering, the \"replacement\" is implemented by holding the
+-- latest output 'Behavior' and sampling it at render time.
+--
+-- In practice, only the initial widget's HTML appears in the output of
+-- 'renderStatic', because no events ever fire during static rendering.
+-- The replacement event @a'@ is effectively dead code in this context.
+--
+-- HTML comment markers (@\<!-- replace-start-N --\>@ / @\<!-- replace-end-N --\>@)
+-- are inserted around the replaceable region. The hydration system uses these
+-- markers to locate the DOM region that needs to be taken over on the client.
+--
+-- 'traverseDMapWithKeyWithAdjust' (used by 'listWithKey', etc.) similarly
+-- renders all initial children and holds their outputs, merging them at
+-- sample time.
 instance (Reflex t, Adjustable t m, MonadHold t m, SupportsStaticDomBuilder t m) => Adjustable t (StaticDomBuilderT t m) where
   runWithReplace a0 a' = do
     e <- StaticDomBuilderT ask
@@ -383,8 +482,44 @@ instance SupportsStaticDomBuilder t m => DomBuilder t (StaticDomBuilderT t m) wh
   wrapRawElement () _ = return $ Element (EventSelector $ const never) ()
 
 --TODO: Make this more abstract --TODO: Put the WithWebView underneath PerformEventT - I think this would perform better
+
+-- | Concrete monad stack for static rendering. This is what 'renderStatic'
+-- runs your widget in.
+--
+-- @
+-- StaticWidget x ≈ PostBuildT DomTimeline
+--                    (StaticDomBuilderT DomTimeline
+--                      (PerformEventT DomTimeline DomHost))
+-- @
+--
+-- The @x@ parameter is unused (it exists for compatibility with
+-- 'Reflex.Dom.Main.Widget' which also takes @x@).
+--
+-- You rarely need to refer to this type directly. Write polymorphic widgets
+-- with @DomBuilder t m@ constraints instead.
 type StaticWidget x = PostBuildT DomTimeline (StaticDomBuilderT DomTimeline (PerformEventT DomTimeline DomHost))
 
+-- | Render a reflex-dom widget to an HTML 'ByteString'.
+--
+-- This is the main entry point for server-side rendering. The widget runs in
+-- 'StaticDomBuilderT', so all events are 'never' and no JavaScript context
+-- is available. The result is a strict 'ByteString' containing the rendered
+-- HTML.
+--
+-- For client-side entry points, see 'mainWidget' and 'mainWidgetWithHead'
+-- from "Reflex.Dom.Main".
+--
+-- @
+-- (result, htmlBytes) <- renderStatic $ do
+--   el \"div\" $ do
+--     elAttr \"a\" (\"href\" =: \"\/about\") $ text \"About\"
+--   return someValue
+-- @
+--
+-- The returned @result@ is whatever your widget returns (useful for extracting
+-- metadata during rendering). The @htmlBytes@ is the serialized HTML.
+--
+-- @since 0.8.0.0
 {-# INLINE renderStatic #-}
 renderStatic :: StaticWidget x a -> IO (a, ByteString)
 renderStatic w = do

--- a/reflex-dom-core/src/Reflex/Dom/Class.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Class.hs
@@ -1,4 +1,17 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+-- |
+-- Module: Reflex.Dom.Class
+--
+-- Utility re-exports and convenience functions. The most important export is
+-- the '(=:)' operator for building single-entry 'Map's (commonly used for
+-- HTML attributes):
+--
+-- @
+-- elAttr \"a\" (\"href\" =: \"\/about\" \<\> \"class\" =: \"link\") $ text \"About\"
+-- @
+--
+-- Also re-exports 'HasJSContext' from "Foreign.JavaScript.TH" and
+-- 'keyCodeLookup' from "Web.KeyCode".
 module Reflex.Dom.Class ( module Reflex.Dom.Class
                         , module Foreign.JavaScript.TH
                         , module Web.KeyCode
@@ -12,7 +25,13 @@ import Foreign.JavaScript.TH
 import Reflex.PerformEvent.Class
 import Reflex.PostBuild.Class
 
--- | Previously an alias for 'Data.Map.singleton', but now generalised to 'At'
+-- | Create a single-entry container. Generalised to 'At', but typically used
+-- with @Map Text Text@ for HTML attributes. Combine multiple attributes with
+-- @(\<\>)@:
+--
+-- @
+-- elAttr \"input\" (\"type\" =: \"text\" \<\> \"placeholder\" =: \"Name\" \<\> \"class\" =: \"input\") blank
+-- @
 (=:) :: (At m, Monoid m) => Index m -> IxValue m -> m
 k =: a = at k ?~ a $ mempty
 infixr 7 =: -- Ought to bind tighter than <>, which is infixr 6
@@ -25,6 +44,13 @@ keycodeEnter = 13
 keycodeEscape :: Int
 keycodeEscape = 27
 
+-- | Run an action at post-build time and hold its result as a 'Behavior'.
+-- Useful for fetching an initial value from the environment (e.g. current
+-- time, config) that the widget needs as a 'Behavior'.
+--
+-- @
+-- now <- holdOnStartup (UTCTime (ModifiedJulianDay 0) 0) getCurrentTime
+-- @
 {-# INLINABLE holdOnStartup #-}
 holdOnStartup :: (PostBuild t m, PerformEvent t m, MonadHold t m) => a -> Performable m a -> m (Behavior t a)
 holdOnStartup a0 ma = do

--- a/reflex-dom-core/src/Reflex/Dom/Location.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Location.hs
@@ -3,6 +3,20 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+-- |
+-- Module: Reflex.Dom.Location
+--
+-- Browser location (URL) and history management for reflex-dom applications.
+--
+-- Provides functions to read the current URL components and to manage
+-- browser history (pushState\/replaceState) reactively via Reflex events.
+--
+-- All functions in this module require 'MonadJSM' since they interact with
+-- the browser's @window.location@ and @window.history@ APIs. They are not
+-- available in static rendering.
+--
+-- In Obelisk applications, URL routing is typically handled at a higher level
+-- by the @Obelisk.Route@ machinery, which uses these primitives internally.
 module Reflex.Dom.Location
   ( browserHistoryWith
   , getLocationAfterHost
@@ -88,6 +102,12 @@ decodeURIText :: (MonadJSM m) => Text -> m Text
 decodeURIText = decodeURI
 
 -- | Builds a Dynamic carrying the current window location.
+-- Updates automatically on @popstate@ events (browser back\/forward).
+--
+-- @
+-- locationDyn <- browserHistoryWith getLocationAfterHost
+-- dynText locationDyn  -- displays e.g. \"\/dashboard?tab=settings\"
+-- @
 browserHistoryWith :: (MonadJSM m, TriggerEvent t m, MonadHold t m)
                    => (forall jsm. MonadJSM jsm => Location -> jsm a)
                    -- ^ A function to encode the window location in a more useful form (e.g. @getLocationAfterHost@).
@@ -146,6 +166,15 @@ getLocationUri location = URI
   <*> Location.getSearch location
   <*> Location.getHash location
 
+-- | Subscribe to history events and execute 'HistoryCommand's, returning a
+-- 'Dynamic' of the current 'HistoryItem'.
+--
+-- @
+-- historyDyn <- manageHistory $ leftmost
+--   [ HistoryCommand_PushState newPageUpdate \<$ navigateEvt
+--   , HistoryCommand_ReplaceState replaceUpdate \<$ replaceEvt
+--   ]
+-- @
 manageHistory :: (MonadJSM m, TriggerEvent t m, MonadHold t m, PerformEvent t m, MonadJSM (Performable m)) => Event t HistoryCommand -> m (Dynamic t HistoryItem)
 manageHistory runCmd = do
   window <- DOM.currentWindowUnchecked

--- a/reflex-dom-core/src/Reflex/Dom/Main.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Main.hs
@@ -12,6 +12,41 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fspecialise-aggressively #-}
+-- |
+-- Module: Reflex.Dom.Main
+--
+-- Application entry points and the concrete 'Widget' type alias.
+--
+-- == The Widget Monad Stack
+--
+-- @
+-- type Widget x = ImmediateDomBuilderT DomTimeline (DomCoreWidget x)
+--
+-- type DomCoreWidget x = PostBuildT DomTimeline
+--   (WithJSContextSingleton x (PerformEventT DomTimeline DomHost))
+--
+-- type DomTimeline = Spider
+-- type DomHost     = SpiderHost Global
+-- @
+--
+-- You rarely need to know this — write polymorphic code with 'DomBuilder',
+-- 'PostBuild', 'MonadHold', etc. constraints instead.
+--
+-- == Entry Points
+--
+-- For standalone apps (not Obelisk):
+--
+-- * 'mainWidget' — run a widget in @\<body\>@
+-- * 'mainWidgetWithHead' — run widgets in both @\<head\>@ and @\<body\>@
+-- * 'mainWidgetWithCss' — inject CSS then run widget in @\<body\>@
+-- * 'mainWidgetInElementById' — run a widget inside a specific element
+--
+-- For server-side rendering:
+--
+-- * 'renderStatic' (from "Reflex.Dom.Builder.Static") — render a widget to 'ByteString'
+--
+-- Obelisk applications use their own entry points that call the hydration
+-- variants ('mainHydrationWidgetWithHead', etc.) internally.
 module Reflex.Dom.Main where
 
 import Prelude hiding (concat, mapM, mapM_, sequence, sequence_)
@@ -185,6 +220,19 @@ runHydrationWidgetWithHeadAndBodyWithFailure onFailure switchoverAction app = wi
     return (events, postBuildTriggerRef)
   liftIO $ processAsyncEvents events fc
 
+-- | Run a widget in the document @\<body\>@, replacing its contents.
+-- This is the simplest entry point for a standalone reflex-dom app.
+--
+-- @
+-- main :: IO ()
+-- main = mainWidget $ do
+--   el \"h1\" $ text \"Hello, reflex!\"
+--   clickEvt <- button \"Click me\"
+--   count <- foldDyn (+) (0 :: Int) (1 \<$ clickEvt)
+--   el \"p\" $ do
+--     text \"Clicks: \"
+--     display count
+-- @
 {-# INLINE mainWidget #-}
 mainWidget :: (forall x. Widget x ()) -> JSM ()
 mainWidget = mainWidget'
@@ -207,6 +255,13 @@ mainWidgetWithHead h b = withJSContextSingletonMono $ \jsSing -> do
   body <- getBodyUnchecked doc
   attachWidget body jsSing b
 
+-- | Inject CSS into @\<head\>@ via a @\<style\>@ tag, then run a widget in @\<body\>@.
+--
+-- @
+-- main :: IO ()
+-- main = mainWidgetWithCss \"body { background: #f0f0f0; }\" $ do
+--   el \"h1\" $ text \"Styled app\"
+-- @
 {-# INLINABLE mainWidgetWithCss #-}
 mainWidgetWithCss :: ByteString -> (forall x. Widget x ()) -> JSM ()
 mainWidgetWithCss css w = withJSContextSingleton $ \jsSing -> do
@@ -236,6 +291,16 @@ runDomHost = runSpiderHost
   . runProfiledM
 #endif
 
+-- | The concrete widget monad for GHCJS applications. This is the fully
+-- instantiated monad stack that 'mainWidget' and 'attachWidget' run.
+--
+-- The outermost layer is 'ImmediateDomBuilderT', which provides the
+-- 'DomBuilder' instance backed by real GHCJS DOM operations.
+--
+-- In practice, write widgets with polymorphic constraints ('DomBuilder',
+-- 'PostBuild', 'MonadHold', etc.) rather than using this type directly.
+-- The polymorphic style lets the same code run in static rendering
+-- ('StaticDomBuilderT') and GHCJS ('Widget').
 type Widget x = ImmediateDomBuilderT DomTimeline (DomCoreWidget x)
 
 {-# INLINABLE attachWidget #-}
@@ -343,7 +408,15 @@ processAsyncEvents events (FireCommand fire) = void $ forkIO $ forever $ do
     liftIO $ forM_ ers $ \(_ :=> TriggerInvocation _ cb) -> cb
   return ()
 
--- | Run a reflex-dom application inside of an existing DOM element with the given ID
+-- | Run a reflex-dom application inside of an existing DOM element with the given ID.
+-- Useful for embedding a Reflex app within a larger page.
+--
+-- @
+-- \-\- Given \<div id=\"app\"\>\<\/div\> in the HTML:
+-- main :: IO ()
+-- main = mainWidgetInElementById \"app\" $ do
+--   el \"p\" $ text \"I live inside #app\"
+-- @
 mainWidgetInElementById :: Text -> (forall x. Widget x ()) -> JSM ()
 mainWidgetInElementById eid w = withJSContextSingleton $ \jsSing -> do
   doc <- currentDocumentUnchecked

--- a/reflex-dom-core/src/Reflex/Dom/Old.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Old.hs
@@ -11,6 +11,40 @@
 #ifdef USE_TEMPLATE_HASKELL
 {-# LANGUAGE TemplateHaskell #-}
 #endif
+-- |
+-- Module: Reflex.Dom.Old
+--
+-- Legacy API from reflex-dom 0.x. This module is __deprecated__ — prefer
+-- using 'DomBuilder' constraints and the functions from
+-- "Reflex.Dom.Widget.Basic" instead.
+--
+-- == Why this exists
+--
+-- Early reflex-dom versions used 'MonadWidget' as the primary constraint for
+-- all widget code. This was a \"kitchen sink\" constraint that bundled together
+-- everything you could possibly need ('DomBuilder', 'MonadHold', 'PostBuild',
+-- 'PerformEvent', 'TriggerEvent', 'MonadIO', 'MonadJSM', 'MonadRef', etc.).
+--
+-- The problem: 'MonadWidget' forces @DomBuilderSpace m ~ GhcjsDomSpace@,
+-- which means any widget using 'MonadWidget' __cannot__ be rendered statically
+-- via 'renderStatic'. Modern reflex-dom code should use polymorphic
+-- constraints (@DomBuilder t m@) so the same widget works in both static
+-- and GHCJS contexts.
+--
+-- == Migration
+--
+-- Replace @MonadWidget t m =>@ with the specific constraints you actually need:
+--
+-- @
+-- -- Old (locked to GHCJS):
+-- myWidget :: MonadWidget t m => m ()
+--
+-- -- New (works in static and GHCJS):
+-- myWidget :: (DomBuilder t m, PostBuild t m, MonadHold t m) => m ()
+-- @
+--
+-- Only add constraints you actually use. The 'DomBuilder' constraint alone
+-- covers @el@, @text@, @elAttr@, etc.
 module Reflex.Dom.Old
        ( MonadWidget
        , El
@@ -101,6 +135,11 @@ elConfig_attributes f (ElConfig a b) = (\b' -> ElConfig a b') <$> f b
 {-# INLINE elConfig_attributes #-}
 #endif
 
+-- | The full set of constraints that 'MonadWidget' demands.
+--
+-- Note the @DomBuilderSpace m ~ GhcjsDomSpace@ constraint, which is why
+-- 'MonadWidget' code cannot run in static rendering. Avoid using this directly;
+-- prefer individual polymorphic constraints.
 type MonadWidgetConstraints t m =
   ( DomBuilder t m
   , DomBuilderSpace m ~ GhcjsDomSpace
@@ -124,6 +163,15 @@ type MonadWidgetConstraints t m =
   , Ref (Performable m) ~ Ref IO
   )
 
+-- | __Deprecated.__ A \"kitchen sink\" constraint alias bundling every
+-- capability a widget could need. Any monad satisfying 'MonadWidgetConstraints'
+-- is automatically an instance.
+--
+-- The key problem: this forces @DomBuilderSpace m ~ GhcjsDomSpace@,
+-- preventing static rendering. Use individual constraints ('DomBuilder',
+-- 'PostBuild', 'MonadHold', etc.) instead.
+--
+-- @since 0.8.0.0 (deprecated)
 class MonadWidgetConstraints t m => MonadWidget t m
 instance MonadWidgetConstraints t m => MonadWidget t m
 

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -98,10 +98,10 @@ import qualified GHCJS.DOM.Types as DOM
 -- and @DomBuilderSpace m ~ GhcjsDomSpace@.
 type PrerenderClientConstraint t m =
   ( DomBuilder t m
-  , DomBuilderSpace m ~ GhcjsDomSpace  -- ^ Real DOM elements, not ()
+  , DomBuilderSpace m ~ GhcjsDomSpace
   , DomRenderHook t m
-  , HasDocument m                       -- ^ Access to DOM.Document
-  , TriggerEvent t m                    -- ^ Create events from callbacks
+  , HasDocument m
+  , TriggerEvent t m
   , PrerenderBaseConstraints t m
   )
 
@@ -111,8 +111,8 @@ type PrerenderClientConstraint t m =
 type PrerenderBaseConstraints t m =
   ( MonadFix m
   , MonadHold t m
-  , MonadJSM (Performable m)           -- ^ Run JS in event handlers
-  , MonadJSM m                         -- ^ Run JS directly
+  , MonadJSM (Performable m)
+  , MonadJSM m
   , MonadRef (Performable m)
   , MonadRef m
   , MonadReflexCreateTrigger t m

--- a/reflex-dom-core/src/Reflex/Dom/Prerender.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Prerender.hs
@@ -14,7 +14,54 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
--- | Render the first widget on the server, and the second on the client.
+-- |
+-- Module: Reflex.Dom.Prerender
+--
+-- Split code between server-side and client-side rendering. The 'Prerender'
+-- typeclass lets you write a server-side widget (static HTML) and a
+-- client-side widget (full GHCJS interactivity) in the same codebase.
+--
+-- == How It Works
+--
+-- @'prerender' serverWidget clientWidget@ behaves differently depending on context:
+--
+-- * __Static__ ('StaticDomBuilderT'): Runs @serverWidget@, ignores @clientWidget@.
+--   Returns @constDyn result@. The client widget is never built.
+--
+-- * __GHCJS__ ('HydrationDomBuilderT' 'GhcjsDomSpace'): Only runs @clientWidget@.
+--   Returns @constDyn result@. The server widget is never built.
+--
+-- * __Hydration__ ('HydrationDomBuilderT' 'HydrationDomSpace'): Runs @serverWidget@
+--   initially. After switchover (when the client takes over from the server-rendered
+--   HTML), runs @clientWidget@ and returns a 'Dynamic' that switches from the server
+--   result to the client result.
+--
+-- == The @Client m@ Type
+--
+-- The @Client m@ associated type is the monad in which the client widget runs.
+-- It always satisfies 'PrerenderClientConstraint', which includes:
+--
+-- * 'DomBuilderSpace' @(Client m) ~ GhcjsDomSpace@ — real DOM access
+-- * 'MonadJSM' — JavaScript execution via @liftJSM@
+-- * 'HasDocument' — access to @DOM.Document@
+-- * 'TriggerEvent' — create events from callbacks
+-- * 'MonadHold', 'PostBuild', 'PerformEvent', 'MonadFix', etc.
+--
+-- For 'StaticDomBuilderT', @Client m@ is 'UnrunnableT' — a phantom monad that
+-- satisfies the type constraints but can never actually be executed (since there
+-- is no JavaScript context on the server).
+--
+-- == Common Pattern
+--
+-- Use 'prerender_' (note the underscore) when you don't need the result:
+--
+-- @
+-- prerender_ (text \"Loading...\") $ do
+--   \-\- Full GHCJS access here
+--   (btn, _) <- el\' \"button\" $ text \"Click\"
+--   count <- foldDyn (+) (0 :: Int) (1 \<$ domEvent Click btn)
+--   el \"span\" $ display count
+-- @
 module Reflex.Dom.Prerender
        ( Prerender (..)
        , prerender_
@@ -46,20 +93,26 @@ import qualified GHCJS.DOM.Document as Document
 import qualified GHCJS.DOM.Node as Node
 import qualified GHCJS.DOM.Types as DOM
 
+-- | The full constraint set available inside @Client m@. This is what you can
+-- use inside the client block of 'prerender'. Notably includes 'MonadJSM'
+-- and @DomBuilderSpace m ~ GhcjsDomSpace@.
 type PrerenderClientConstraint t m =
   ( DomBuilder t m
-  , DomBuilderSpace m ~ GhcjsDomSpace
+  , DomBuilderSpace m ~ GhcjsDomSpace  -- ^ Real DOM elements, not ()
   , DomRenderHook t m
-  , HasDocument m
-  , TriggerEvent t m
+  , HasDocument m                       -- ^ Access to DOM.Document
+  , TriggerEvent t m                    -- ^ Create events from callbacks
   , PrerenderBaseConstraints t m
   )
 
+-- | Base constraints shared between client and hydration contexts.
+-- Includes 'MonadJSM' (JavaScript execution), 'MonadHold' (state),
+-- 'PerformEvent' (side effects), and 'PostBuild' (initialization).
 type PrerenderBaseConstraints t m =
   ( MonadFix m
   , MonadHold t m
-  , MonadJSM (Performable m)
-  , MonadJSM m
+  , MonadJSM (Performable m)           -- ^ Run JS in event handlers
+  , MonadJSM m                         -- ^ Run JS directly
   , MonadRef (Performable m)
   , MonadRef m
   , MonadReflexCreateTrigger t m
@@ -78,12 +131,33 @@ prerender_
   => m () ->  Client m () -> m ()
 prerender_ server client = void $ prerender server client
 
+-- | Split rendering between server and client contexts.
+--
+-- The key 'DomBuilder' implementations are 'StaticDomBuilderT'
+-- (from "Reflex.Dom.Builder.Static") for server-side rendering, and
+-- 'HydrationDomBuilderT' / 'ImmediateDomBuilderT'
+-- (from "Reflex.Dom.Builder.Immediate") for client-side rendering.
+--
+-- == Instances
+--
+-- * 'StaticDomBuilderT': @Client m = UnrunnableT@ (phantom, never executes).
+--   'prerender' runs the server widget only.
+-- * @'HydrationDomBuilderT' 'GhcjsDomSpace'@: @Client m = m@ (same monad).
+--   'prerender' runs the client widget only.
+-- * @'HydrationDomBuilderT' 'HydrationDomSpace'@: @Client m = PostBuildT t (HydrationDomBuilderT GhcjsDomSpace t m)@.
+--   'prerender' runs the server widget first, then the client widget after switchover.
+-- * 'ReaderT', 'RequesterT', 'EventWriterT', etc. all lift through transparently.
+--
+-- @since 0.8.0.0
 class (PrerenderClientConstraint t (Client m), Client (Client m) ~ Client m, Prerender t (Client m)) => Prerender t m | m -> t where
-  -- | Monad in which the client widget is built
+  -- | The monad in which the client widget is built. In 'StaticDomBuilderT' this
+  -- is 'UnrunnableT' (a phantom monad). In GHCJS it is the same builder monad.
   type Client m :: * -> *
-  -- | Render the first widget on the server, and the second on the client. The
-  -- hydration builder will run *both* widgets, updating the result dynamic at
-  -- switchover time.
+  -- | Render the first widget on the server, and the second on the client.
+  --
+  -- Returns a 'Dynamic' that holds the server widget's result initially, then
+  -- switches to the client widget's result after switchover (hydration) or
+  -- immediately (pure GHCJS). In static rendering, returns @constDyn serverResult@.
   prerender :: m a -> Client m a -> m (Dynamic t a)
 
 instance (ReflexHost t, Adjustable t m, PrerenderBaseConstraints t m) => Prerender t (HydrationDomBuilderT GhcjsDomSpace t m) where

--- a/reflex-dom-core/src/Reflex/Dom/Tutorial.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Tutorial.hs
@@ -1,0 +1,868 @@
+-- |
+-- Module: Reflex.Dom.Tutorial
+-- Description: A guided walkthrough of reflex-dom for working developers.
+-- Stability: experimental
+--
+-- This is a documentation-only module. It exports nothing and contains no
+-- executable code. Its purpose is to provide a structured, practical
+-- introduction to reflex-dom's core concepts, types, and patterns.
+--
+-- The intended audience is someone who already knows Haskell and wants to
+-- build web UIs with reflex-dom. The focus is on what you need day-to-day,
+-- not exhaustive API coverage.
+module Reflex.Dom.Tutorial
+  ( -- * Getting Started
+    -- $getting-started
+
+    -- * The DomBuilder Constraint
+    -- $dombuilder
+
+    -- * Three DOM Spaces
+    -- $dom-spaces
+
+    -- * Building Elements
+    -- $building-elements
+
+    -- * Text and Dynamic Content
+    -- $text-and-dynamic
+
+    -- * Events
+    -- $events
+
+    -- * The Element Type
+    -- $element-type
+
+    -- * Input Widgets
+    -- $input-widgets
+
+    -- * Prerender
+    -- $prerender
+
+    -- * Common Constraint Patterns
+    -- $constraint-patterns
+
+    -- * Gotchas and Anti-Patterns
+    -- $gotchas
+  ) where
+
+-- $getting-started
+--
+-- == What Is reflex-dom?
+--
+-- reflex-dom is a Haskell library for building reactive web interfaces. It sits
+-- on top of reflex (the FRP engine) and provides a way to construct and
+-- manipulate the DOM using ordinary Haskell code.
+--
+-- The central idea: __widgets are monadic computations that build DOM.__
+--
+-- When you write:
+--
+-- @
+-- myWidget :: DomBuilder t m => m ()
+-- myWidget = do
+--   el "h1" $ text "Hello"
+--   el "p"  $ text "Welcome to reflex-dom."
+-- @
+--
+-- ...you are writing a monadic action in some monad @m@ that, when executed,
+-- produces an @\<h1\>@ and a @\<p\>@ in the document. There is no virtual DOM,
+-- no diffing, and no render cycle. The DOM is built once, and then specific
+-- parts of it are updated in response to 'Event's and 'Dynamic's from the
+-- reflex FRP layer.
+--
+-- The monadic structure gives you sequencing (elements appear in the order
+-- you write them), scoping (child widgets are nested inside parent elements),
+-- and composition (widgets can call other widgets and pass values between them).
+--
+-- @
+-- page :: DomBuilder t m => m ()
+-- page = el "div" $ do
+--   header        -- build the header DOM
+--   mainContent   -- build the body DOM
+--   footer        -- build the footer DOM
+-- @
+--
+-- This is a pure Haskell function. No JSX, no templates, no special syntax.
+-- Types enforce that DOM-building code lives in a monad with the 'DomBuilder'
+-- constraint. The same code can render to a live browser (GHCJS), to static
+-- HTML (server-side), or participate in hydration (SSR takeover).
+
+-- $dombuilder
+--
+-- == The DomBuilder Constraint
+--
+-- 'DomBuilder' is the foundation of all DOM-constructing code in reflex-dom.
+-- Its full class header is:
+--
+-- @
+-- class (Monad m, Reflex t, DomSpace (DomBuilderSpace m), NotReady t m, Adjustable t m)
+--       => DomBuilder t m | m -> t
+-- @
+--
+-- This gives you:
+--
+-- * 'Monad' @m@ -- sequencing and composition via @do@-notation.
+-- * 'Reflex' @t@ -- the FRP timeline (you can work with 'Event' and 'Dynamic').
+-- * 'DomSpace' -- a type family that says which rendering backend this monad
+--   targets (static, GHCJS, or hydration).
+-- * 'NotReady' @t m@ -- the ability to signal that a widget is not yet ready
+--   (used internally by the framework).
+-- * 'Adjustable' @t m@ -- the ability to replace or modify parts of the DOM
+--   dynamically ('runWithReplace', which powers 'dyn' and 'widgetHold').
+--
+-- __What DomBuilder intentionally does NOT include:__
+--
+-- * 'MonadHold' @t m@ -- holding state across time.
+-- * 'PostBuild' @t m@ -- the post-build event.
+-- * 'PerformEvent' @t m@ -- performing IO in response to events.
+-- * 'TriggerEvent' @t m@ -- creating events from external callbacks.
+-- * 'MonadJSM' -- running raw JavaScript.
+-- * 'MonadIO' -- performing arbitrary IO.
+--
+-- You add these constraints explicitly, only when you need them. This is the
+-- key design principle: __write your constraint as small as possible.__
+--
+-- == Why Polymorphic Constraints Matter
+--
+-- The old 'MonadWidget' constraint (from "Reflex.Dom.Old") bundles everything
+-- together AND forces @DomBuilderSpace m ~ GhcjsDomSpace@. That means any
+-- widget using 'MonadWidget' can only run in GHCJS -- it cannot be rendered
+-- on the server via 'renderStatic' or participate in hydration.
+--
+-- By writing @DomBuilder t m@ instead, your widget is polymorphic over the
+-- DOM space and works in all three rendering contexts:
+--
+-- @
+-- -- GOOD: works everywhere
+-- greeting :: DomBuilder t m => m ()
+-- greeting = el "p" $ text "Hello, world!"
+--
+-- -- BAD: locked to GHCJS only
+-- greeting :: MonadWidget t m => m ()
+-- greeting = el "p" $ text "Hello, world!"
+-- @
+--
+-- Only reach for more constraints when you actually need them. If you need
+-- dynamic attributes, add 'PostBuild'. If you need to hold state, add
+-- 'MonadHold'. If you need JavaScript interop, use 'prerender' to isolate
+-- that code to the client.
+
+-- $dom-spaces
+--
+-- == Three DOM Spaces
+--
+-- reflex-dom can render your widget code in three different contexts, selected
+-- by the 'DomBuilderSpace' type family. When you write polymorphic code
+-- (@DomBuilder t m@), the same widget runs correctly in all three.
+--
+-- === StaticDomSpace
+--
+-- Used by 'renderStatic' and the Obelisk static site generator. Your widget
+-- code runs on the server (GHC, not GHCJS) and produces HTML as a
+-- @ByteString@.
+--
+-- * All raw element types ('RawElement', 'RawTextNode', etc.) are @()@.
+-- * All events are 'never' -- no event ever fires.
+-- * All 'Dynamic' values are constant (stuck at their initial value).
+-- * There is no JavaScript context, no 'MonadJSM'.
+-- * @inputElement@ works but its @_inputElement_value@ is @constDyn initialValue@.
+--
+-- This is the context where your code produces the initial server-rendered HTML
+-- that gets sent to the browser before JavaScript loads.
+--
+-- === GhcjsDomSpace
+--
+-- The live browser context. Your code runs in GHCJS and has full access to
+-- the real DOM.
+--
+-- * Raw elements are real jsaddle-dom types (@DOM.Element@, @DOM.Text@, etc.).
+-- * Events fire from @addEventListener@ callbacks.
+-- * 'Dynamic' values update in real time.
+-- * 'MonadJSM' is available (inside 'prerender' or when the constraint is satisfied).
+-- * @inputElement@ values are two-way bound to the live DOM input.
+--
+-- This is the context for a pure client-side app or the client half of a
+-- 'prerender' block.
+--
+-- === HydrationDomSpace
+--
+-- The hybrid SSR-to-live-client takeover context. Used by Obelisk's
+-- @ob run@ and production deployment.
+--
+-- * Initially, the server renders static HTML (like 'StaticDomSpace').
+-- * The browser receives this HTML and displays it immediately.
+-- * GHCJS loads and \"hydrates\": it walks the existing DOM nodes, attaches
+--   event handlers, and takes over. After switchover, it behaves like
+--   'GhcjsDomSpace'.
+--
+-- The key subtlety: code in 'HydrationDomSpace' runs /twice/. The server
+-- pass produces the HTML. The client pass reattaches to it. 'prerender' lets
+-- you provide different code for each pass.
+--
+-- === When Code Runs in Each Space
+--
+-- @
+-- +-------------------+---------------------------+---------------------------+
+-- | Your Code         | Static (Server)           | GHCJS (Client)            |
+-- +-------------------+---------------------------+---------------------------+
+-- | el, text, elAttr  | Produces HTML bytes        | Creates live DOM nodes    |
+-- | dyn, dyn_         | Renders initial value only | Replaces DOM on change    |
+-- | domEvent          | Returns \'never\'            | Returns real event stream |
+-- | inputElement      | constDyn initialValue      | Two-way bound to DOM      |
+-- | prerender s c     | Runs s, ignores c          | Runs c, ignores s         |
+-- +-------------------+---------------------------+---------------------------+
+-- @
+
+-- $building-elements
+--
+-- == Building Elements
+--
+-- The everyday functions for creating DOM elements live in
+-- "Reflex.Dom.Widget.Basic". They are all built on the low-level 'element'
+-- method from 'DomBuilder' but provide a much nicer interface.
+--
+-- === el -- The Simplest Element Builder
+--
+-- @
+-- el :: DomBuilder t m => Text -> m a -> m a
+-- @
+--
+-- Creates an element with the given tag name and runs the child widget inside it:
+--
+-- @
+-- el "div" $ do
+--   el "h1" $ text "Title"
+--   el "p"  $ text "Paragraph"
+-- @
+--
+-- Produces: @\<div\>\<h1\>Title\<\/h1\>\<p\>Paragraph\<\/p\>\<\/div\>@
+--
+-- === elAttr -- Element with Static Attributes
+--
+-- @
+-- elAttr :: DomBuilder t m => Text -> Map Text Text -> m a -> m a
+-- @
+--
+-- @
+-- elAttr "a" ("href" =: "https:\/\/example.com" \<\> "target" =: "_blank") $
+--   text "Click here"
+-- @
+--
+-- The @=:@ operator (from @Data.Map@) creates a singleton map. Use @\<\>@ to
+-- combine multiple attributes.
+--
+-- === elClass -- Element with a CSS Class
+--
+-- @
+-- elClass :: DomBuilder t m => Text -> Text -> m a -> m a
+-- @
+--
+-- @
+-- elClass "div" "container mx-auto" $ do
+--   elClass "p" "text-lg" $ text "Styled paragraph"
+-- @
+--
+-- This is the most commonly used element builder in practice, since most
+-- elements just need a class string.
+--
+-- === elDynAttr -- Element with Dynamic Attributes
+--
+-- @
+-- elDynAttr :: (DomBuilder t m, PostBuild t m) => Text -> Dynamic t (Map Text Text) -> m a -> m a
+-- @
+--
+-- The attributes can change over time. Note the additional 'PostBuild' constraint:
+--
+-- @
+-- elDynAttr "div" (ffor isActive $ \\active ->
+--   if active
+--     then "class" =: "bg-green-500"
+--     else "class" =: "bg-gray-300"
+--   ) $ text "Status"
+-- @
+--
+-- In static rendering, the initial value of the 'Dynamic' is used and the
+-- attributes never update. In GHCJS, attribute changes are applied to the
+-- live DOM element via @setAttribute@\/@removeAttribute@.
+--
+-- === Primed Variants
+--
+-- Every element builder has a primed version (@el'@, @elAttr'@, @elClass'@,
+-- @elDynAttr'@) that returns the 'Element' handle alongside the child result:
+--
+-- @
+-- (btnEl, _) <- el' "button" $ text "Click me"
+-- let clicks = domEvent Click btnEl  -- Event t ()
+-- @
+--
+-- The non-primed versions discard the element handle for convenience. Use the
+-- primed version when you need to attach event handlers (see the Events
+-- section).
+
+-- $text-and-dynamic
+--
+-- == Text and Dynamic Content
+--
+-- === Static Text
+--
+-- @
+-- text :: DomBuilder t m => Text -> m ()
+-- @
+--
+-- Creates a text node. This is the leaf of your DOM tree:
+--
+-- @
+-- el "p" $ text "This is a paragraph."
+-- @
+--
+-- === Dynamic Text
+--
+-- @
+-- dynText :: (DomBuilder t m, PostBuild t m) => Dynamic t Text -> m ()
+-- @
+--
+-- Displays a 'Dynamic' text value. When the 'Dynamic' updates, the text node
+-- in the DOM is replaced:
+--
+-- @
+-- nameD <- holdDyn "World" nameChangeEvent
+-- el "p" $ do
+--   text "Hello, "
+--   dynText nameD
+-- @
+--
+-- === display -- Show Any Value
+--
+-- @
+-- display :: (DomBuilder t m, PostBuild t m, Show a) => Dynamic t a -> m ()
+-- @
+--
+-- Like 'dynText' but calls 'show' on the value first. Handy for debugging
+-- or displaying numbers:
+--
+-- @
+-- counter <- foldDyn (+) (0 :: Int) (1 \<$ clickEvt)
+-- el "span" $ display counter
+-- @
+--
+-- === dyn and dyn_ -- Dynamic Widget Replacement
+--
+-- @
+-- dyn  :: (DomBuilder t m, PostBuild t m) => Dynamic t (m a) -> m (Event t a)
+-- dyn_ :: (DomBuilder t m, PostBuild t m) => Dynamic t (m a) -> m ()
+-- @
+--
+-- 'dyn' takes a 'Dynamic' containing a /widget/ and rebuilds the DOM every
+-- time the 'Dynamic' changes. The old DOM is destroyed and the new widget's
+-- DOM is inserted in its place.
+--
+-- @
+-- dyn_ $ ffor currentPage $ \\case
+--   HomePage    -> homeWidget
+--   AboutPage   -> aboutWidget
+--   ContactPage -> contactWidget
+-- @
+--
+-- __Performance note:__ 'dyn' destroys and rebuilds the entire subtree on
+-- every change. For large widgets, prefer updating individual attributes or
+-- text nodes via 'Dynamic' values rather than replacing the whole widget.
+--
+-- === widgetHold -- Dynamic Widget with State
+--
+-- @
+-- widgetHold  :: (Adjustable t m, MonadHold t m) => m a -> Event t (m a) -> m (Dynamic t a)
+-- widgetHold_ :: (Adjustable t m, MonadHold t m) => m a -> Event t (m a) -> m ()
+-- @
+--
+-- Like 'dyn' but driven by an 'Event' instead of a 'Dynamic'. Takes an
+-- initial widget and an event that fires replacement widgets:
+--
+-- @
+-- widgetHold_ (text "Loading...") (buildResultWidget \<$\> responseEvt)
+-- @
+--
+-- Note the different constraint: 'Adjustable' and 'MonadHold' instead of
+-- 'PostBuild'. This is because 'widgetHold' works at a lower level than
+-- 'dyn'.
+
+-- $events
+--
+-- == Events
+--
+-- DOM events are extracted from 'Element' handles using 'domEvent'. The type
+-- of data you get back depends on which event you select.
+--
+-- === domEvent
+--
+-- @
+-- domEvent :: HasDomEvent t target eventName
+--          => EventName eventName -> target -> Event t (DomEventType target eventName)
+-- @
+--
+-- The 'EventName' constructors (from "Reflex.Dom.Builder.Class.Events") are
+-- the first argument. The 'Element' (or 'InputElement', etc.) is the second.
+--
+-- @
+-- (e, _) <- el' "div" $ text "Click or type here"
+-- let click    = domEvent Click e     -- Event t ()
+-- let keypress = domEvent Keypress e  -- Event t Word
+-- let mousePos = domEvent Mousemove e -- Event t (Int, Int)
+-- @
+--
+-- === EventName Constructors (Partial List)
+--
+-- @
+-- Click       :: EventName \'ClickTag
+-- Dblclick    :: EventName \'DblclickTag
+-- Keypress    :: EventName \'KeypressTag
+-- Keydown     :: EventName \'KeydownTag
+-- Keyup       :: EventName \'KeyupTag
+-- Mousemove   :: EventName \'MousemoveTag
+-- Mousedown   :: EventName \'MousedownTag
+-- Mouseup     :: EventName \'MouseupTag
+-- Mouseenter  :: EventName \'MouseenterTag
+-- Mouseleave  :: EventName \'MouseleaveTag
+-- Scroll      :: EventName \'ScrollTag
+-- Focus       :: EventName \'FocusTag
+-- Blur        :: EventName \'BlurTag
+-- Input       :: EventName \'InputTag
+-- Change      :: EventName \'ChangeTag
+-- Submit      :: EventName \'SubmitTag
+-- Paste       :: EventName \'PasteTag
+-- Wheel       :: EventName \'WheelTag
+-- Touchstart  :: EventName \'TouchstartTag
+-- Touchmove   :: EventName \'TouchmoveTag
+-- Touchend    :: EventName \'TouchendTag
+-- Touchcancel :: EventName \'TouchcancelTag
+-- @
+--
+-- === EventResultType Mappings
+--
+-- Each event name maps to a specific result type via the 'EventResultType'
+-- type family. This determines what type @domEvent SomeEvent el@ returns:
+--
+-- @
+-- domEvent Click el      :: Event t ()             -- fire-and-forget
+-- domEvent Dblclick el   :: Event t (Int, Int)     -- mouse coordinates
+-- domEvent Keypress el   :: Event t Word           -- key code
+-- domEvent Keydown el    :: Event t Word           -- key code
+-- domEvent Keyup el      :: Event t Word           -- key code
+-- domEvent Scroll el     :: Event t Double         -- scroll position
+-- domEvent Mousemove el  :: Event t (Int, Int)     -- mouse coordinates
+-- domEvent Mousedown el  :: Event t (Int, Int)     -- mouse coordinates
+-- domEvent Mouseup el    :: Event t (Int, Int)     -- mouse coordinates
+-- domEvent Mouseenter el :: Event t ()
+-- domEvent Mouseleave el :: Event t ()
+-- domEvent Focus el      :: Event t ()
+-- domEvent Blur el       :: Event t ()
+-- domEvent Input el      :: Event t ()             -- use _inputElement_value for text
+-- domEvent Change el     :: Event t ()
+-- domEvent Submit el     :: Event t ()
+-- domEvent Paste el      :: Event t (Maybe Text)   -- clipboard text, if available
+-- domEvent Touchstart el :: Event t TouchEventResult
+-- domEvent Wheel el      :: Event t WheelEventResult
+-- @
+--
+-- Most events return @()@ -- the event /firing/ is the information.
+-- Keyboard events carry the key code as a 'Word'. Mouse events carry
+-- @(Int, Int)@ coordinates. Touch events carry 'TouchEventResult'
+-- (which includes modifier keys and a list of 'TouchResult' touch points).
+--
+-- === Important: Events in Static Context
+--
+-- In 'StaticDomSpace', 'domEvent' always returns 'never'. No events ever
+-- fire during server-side rendering. Any code that depends on events will
+-- simply never execute in the static context, which is usually fine (the
+-- server just produces the initial HTML).
+
+-- $element-type
+--
+-- == The Element Type
+--
+-- When you use a primed element builder (@el'@, @elAttr'@, etc.), you get
+-- back an 'Element' value:
+--
+-- @
+-- data Element er d t = Element
+--   { _element_events :: EventSelector t (WrapArg er EventName)
+--   , _element_raw    :: RawElement d
+--   }
+-- @
+--
+-- === _element_events
+--
+-- An 'EventSelector' that can produce an 'Event' for any DOM event type.
+-- You do not use this directly -- instead, use 'domEvent' which wraps the
+-- selector lookup and coercion:
+--
+-- @
+-- (e, _) <- el' "button" $ text "Go"
+-- let click = domEvent Click e  -- uses _element_events internally
+-- @
+--
+-- === _element_raw
+--
+-- The raw underlying DOM node. Its type depends on the DOM space:
+--
+-- * 'StaticDomSpace': @()@ -- there is no real node.
+-- * 'GhcjsDomSpace': @DOM.Element@ -- a real jsaddle-dom element.
+-- * 'HydrationDomSpace': @()@ until switchover, then a real node.
+--
+-- In GHCJS, you can use @_element_raw@ to call jsaddle-dom functions
+-- directly on the element (e.g., @getBoundingClientRect@, @scrollIntoView@).
+-- This requires 'MonadJSM', so it should be inside a 'prerender' block.
+--
+-- === Using domEvent: A Complete Example
+--
+-- @
+-- clickCounter :: (DomBuilder t m, PostBuild t m, MonadHold t m, MonadFix m) => m ()
+-- clickCounter = el "div" $ do
+--   (btnEl, _) <- el' "button" $ text "+1"
+--   count <- foldDyn (+) (0 :: Int) (1 \<$ domEvent Click btnEl)
+--   el "span" $ display count
+-- @
+--
+-- Breakdown:
+--
+-- 1. @el' "button"@ creates a @\<button\>@ and returns the 'Element' handle.
+-- 2. @domEvent Click btnEl@ extracts the click event as @Event t ()@.
+-- 3. @1 \<$ ...@ replaces the @()@ payload with the integer @1@.
+-- 4. @foldDyn (+) 0@ accumulates the count into a @Dynamic t Int@.
+-- 5. @display count@ renders the current count, updating on each click.
+
+-- $input-widgets
+--
+-- == Input Widgets
+--
+-- === inputElement (Preferred)
+--
+-- @
+-- inputElement :: DomBuilder t m
+--              => InputElementConfig er t (DomBuilderSpace m)
+--              -> m (InputElement er (DomBuilderSpace m) t)
+-- @
+--
+-- This is the modern, preferred way to create @\<input\>@ elements. It returns
+-- an 'InputElement' with reactive access to the input\'s state:
+--
+-- @
+-- i <- inputElement $ def
+--   & inputElementConfig_initialValue .~ ""
+--   & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
+--       ("placeholder" =: "Type here..." \<\> "type" =: "text")
+--
+-- let currentValue = _inputElement_value i   -- Dynamic t Text
+-- let inputEvt     = _inputElement_input i   -- Event t Text (on user typing)
+-- let hasFocus     = _inputElement_hasFocus i -- Dynamic t Bool
+-- @
+--
+-- 'InputElement' is also an instance of 'HasDomEvent', so you can use
+-- 'domEvent' directly on it:
+--
+-- @
+-- let enterKey = domEvent Keypress i  -- Event t Word
+-- @
+--
+-- === textInput (Deprecated)
+--
+-- The older 'textInput' from "Reflex.Dom.Widget.Input" still works but is
+-- deprecated. It wraps 'inputElement' and adds an extra layer of abstraction.
+-- Prefer 'inputElement' directly.
+--
+-- === checkbox
+--
+-- @
+-- checkbox :: (DomBuilder t m, PostBuild t m)
+--          => Bool -> CheckboxConfig t -> m (Checkbox t)
+-- @
+--
+-- @
+-- cb <- checkbox False def
+-- let isChecked = _checkbox_value cb   -- Dynamic t Bool
+-- let changed   = _checkbox_change cb  -- Event t Bool
+-- @
+--
+-- Creates a simple @\<input type=\"checkbox\"\>@ with a reactive 'Dynamic t Bool'
+-- tracking its state.
+--
+-- === dropdown
+--
+-- @
+-- dropdown :: (DomBuilder t m, MonadFix m, MonadHold t m, PostBuild t m, Ord k)
+--          => k -> Dynamic t (Map k Text) -> DropdownConfig t k -> m (Dropdown t k)
+-- @
+--
+-- @
+-- dd <- dropdown "en" (constDyn $ Map.fromList [("en", "English"), ("es", "Spanish")]) def
+-- let selectedLang = _dropdown_value dd  -- Dynamic t Text
+-- @
+--
+-- Creates a @\<select\>@ element. The key type @k@ can be any 'Ord' type.
+-- The 'Map k Text' provides the option values (key) and display labels (value).
+--
+-- === selectElement
+--
+-- @
+-- selectElement :: DomBuilder t m
+--               => SelectElementConfig er t (DomBuilderSpace m)
+--               -> m a
+--               -> m (SelectElement er (DomBuilderSpace m) t, a)
+-- @
+--
+-- Lower-level than 'dropdown'. You provide the @\<option\>@ elements as child
+-- widgets. Returns a 'SelectElement' with @_selectElement_value :: Dynamic t Text@
+-- holding the currently selected value.
+--
+-- @
+-- (sel, _) <- selectElement def $ do
+--   elAttr "option" ("value" =: "a") $ text "Option A"
+--   elAttr "option" ("value" =: "b") $ text "Option B"
+-- let selected = _selectElement_value sel  -- Dynamic t Text
+-- @
+
+-- $prerender
+--
+-- == Prerender: Server\/Client Code Splitting
+--
+-- 'prerender' lets you provide separate implementations for server-side and
+-- client-side rendering:
+--
+-- @
+-- prerender :: (Prerender t m)
+--           => m a           -- ^ Server widget (runs in static context)
+--           -> Client m a    -- ^ Client widget (runs in GHCJS context)
+--           -> m (Dynamic t a)
+-- @
+--
+-- === What Runs Where
+--
+-- * __StaticDomBuilderT__ (server render): Runs the first (server) widget.
+--   The client widget is never built. @Client m@ is @UnrunnableT@ -- a phantom
+--   monad that satisfies type constraints but cannot actually execute.
+--   Returns @constDyn serverResult@.
+--
+-- * __HydrationDomBuilderT GhcjsDomSpace__ (pure GHCJS, no SSR): Runs only
+--   the second (client) widget. The server widget is never built. @Client m@
+--   is the same as @m@. Returns @constDyn clientResult@.
+--
+-- * __HydrationDomBuilderT HydrationDomSpace__ (SSR with hydration): Runs the
+--   server widget first (producing initial HTML). After switchover (when
+--   GHCJS takes over), runs the client widget. Returns a 'Dynamic' that
+--   switches from the server result to the client result.
+--
+-- === The Client m Type
+--
+-- @Client m@ is an associated type that always satisfies
+-- 'PrerenderClientConstraint', which gives you:
+--
+-- * @DomBuilderSpace (Client m) ~ GhcjsDomSpace@ -- real DOM access.
+-- * 'MonadJSM' -- you can call JavaScript via @liftJSM@.
+-- * 'HasDocument' -- access to the @DOM.Document@.
+-- * 'TriggerEvent' -- create events from callbacks.
+-- * 'MonadHold', 'PostBuild', 'PerformEvent', 'MonadFix', etc.
+--
+-- === Common Pattern: prerender_
+--
+-- When you do not need the return value, use 'prerender_' (with underscore):
+--
+-- @
+-- prerender_ (text "Loading...") $ do
+--   \-\- This block only runs on the client
+--   (btn, _) <- el' "button" $ text "Click me"
+--   count <- foldDyn (+) (0 :: Int) (1 \<$ domEvent Click btn)
+--   el "span" $ display count
+-- @
+--
+-- === When to Use Prerender
+--
+-- Use 'prerender' when you need something that only exists on the client:
+--
+-- * JavaScript interop ('MonadJSM', @liftJSM@).
+-- * Access to the raw DOM (@_element_raw@, @getBoundingClientRect@).
+-- * 'TriggerEvent' for creating events from external sources (WebSockets,
+--   timers via @setInterval@, etc.).
+-- * Anything requiring @DomBuilderSpace m ~ GhcjsDomSpace@.
+--
+-- Do NOT use 'prerender' for basic DOM construction (@el@, @text@, @elAttr@)
+-- or for state management (@foldDyn@, @holdDyn@). These work in all contexts.
+
+-- $constraint-patterns
+--
+-- == Common Constraint Patterns
+--
+-- Here is a progression of constraint sets from minimal to maximal, and what
+-- each level gives you.
+--
+-- === DomBuilder t m
+--
+-- The minimum. You can:
+--
+-- * Create elements: @el@, @elAttr@, @elClass@, @text@, @blank@.
+-- * Nest widgets: @el "div" $ childWidget@.
+-- * Use primed variants to get 'Element' handles: @el'@, @elAttr'@.
+-- * Create input elements: @inputElement@.
+--
+-- You cannot:
+--
+-- * Use 'Dynamic'-based functions (@dynText@, @elDynAttr@, @dyn@).
+-- * Hold state (@holdDyn@, @foldDyn@).
+-- * Respond to the post-build event.
+--
+-- @
+-- staticWidget :: DomBuilder t m => m ()
+-- staticWidget = el "p" $ text "Hello"
+-- @
+--
+-- === DomBuilder t m, PostBuild t m
+--
+-- Adds the post-build event and enables 'Dynamic'-based DOM:
+--
+-- * @dynText@ -- display dynamic text.
+-- * @elDynAttr@ -- dynamic attributes.
+-- * @dyn@, @dyn_@ -- replace widgets based on a 'Dynamic'.
+-- * @display@ -- show any 'Show' value dynamically.
+-- * @getPostBuild@ -- get the 'Event' that fires once after the widget is built.
+--
+-- @
+-- dynamicWidget :: (DomBuilder t m, PostBuild t m) => Dynamic t Text -> m ()
+-- dynamicWidget nameDyn = el "p" $ do
+--   text "Hello, "
+--   dynText nameDyn
+-- @
+--
+-- === DomBuilder t m, PostBuild t m, MonadHold t m
+--
+-- Adds state management:
+--
+-- * @holdDyn@ -- hold the latest event value as a 'Dynamic'.
+-- * @foldDyn@ -- accumulate state from events.
+-- * @widgetHold@ -- hold a widget, replacing it on events.
+--
+-- @
+-- statefulWidget :: (DomBuilder t m, PostBuild t m, MonadHold t m, MonadFix m) => m ()
+-- statefulWidget = do
+--   (btn, _) <- el' "button" $ text "Click"
+--   count <- foldDyn (+) (0 :: Int) (1 \<$ domEvent Click btn)
+--   display count
+-- @
+--
+-- === DomBuilder t m, PostBuild t m, MonadHold t m, MonadFix m, PerformEvent t m, MonadIO (Performable m)
+--
+-- The full interactive set. Adds:
+--
+-- * @performEvent@ -- run IO actions in response to events.
+-- * @performEvent_@ -- same but discard the result.
+-- * @MonadIO (Performable m)@ -- the performed action can do IO.
+--
+-- @
+-- ioWidget :: ( DomBuilder t m, PostBuild t m, MonadHold t m, MonadFix m
+--             , PerformEvent t m, MonadIO (Performable m)
+--             ) => m ()
+-- ioWidget = do
+--   (btn, _) <- el' "button" $ text "Log"
+--   performEvent_ $ liftIO (putStrLn "Button clicked!") \<$ domEvent Click btn
+-- @
+--
+-- === When to Use Each
+--
+-- As a rule of thumb:
+--
+-- * Pure layout/structure: @DomBuilder t m@ alone.
+-- * Displaying dynamic data: add @PostBuild t m@.
+-- * User interaction with state: add @MonadHold t m@ and @MonadFix m@.
+-- * Side effects (HTTP, logging, etc.): add @PerformEvent@ and @MonadIO@.
+-- * JavaScript interop: use @prerender@ to isolate to client.
+
+-- $gotchas
+--
+-- == Gotchas and Anti-Patterns
+--
+-- === MonadWidget Locks You to GHCJS
+--
+-- 'MonadWidget' (from "Reflex.Dom.Old") forces @DomBuilderSpace m ~ GhcjsDomSpace@.
+-- Any widget using it cannot be rendered statically or participate in
+-- hydration. Use polymorphic constraints instead:
+--
+-- @
+-- -- Avoid:
+-- myWidget :: MonadWidget t m => m ()
+--
+-- -- Prefer:
+-- myWidget :: (DomBuilder t m, PostBuild t m, MonadHold t m) => m ()
+-- @
+--
+-- === Script Tags Do Not Execute in GHCJS
+--
+-- If you create a @\<script\>@ element via @el "script"@, the browser will NOT
+-- execute it. The DOM spec says dynamically inserted script elements via
+-- @innerHTML@ or @createElement@+@appendChild@ do not automatically run.
+-- GHCJS uses @createElement@ under the hood.
+--
+-- If you need to run JavaScript, use 'MonadJSM' inside a 'prerender' block:
+--
+-- @
+-- prerender_ blank $ liftJSM $ do
+--   \-\- Your JavaScript code here via jsaddle
+--   jsg ("console" :: Text) ^. js1 ("log" :: Text) ("Hello from JS" :: Text)
+-- @
+--
+-- === Events Are Never in Static Context
+--
+-- In 'StaticDomSpace', every 'Event' is 'never'. This means:
+--
+-- * 'domEvent' returns 'never' for all events.
+-- * @_inputElement_input@ is 'never'.
+-- * @_checkbox_change@ is 'never'.
+-- * Any @performEvent@ handler will never fire.
+-- * Any @foldDyn@ will stay at its initial value.
+--
+-- This is by design. The server just produces HTML. If your widget logic
+-- depends on events, it will silently do nothing in the static context.
+-- The client takes over after hydration.
+--
+-- === delay 0.1 for PostBuild Requests
+--
+-- When firing a request in response to @getPostBuild@, the WebSocket
+-- connection (e.g., Rhyolite) may not be established yet. A common
+-- workaround:
+--
+-- @
+-- pb <- getPostBuild
+-- pbDelayed <- delay 0.1 pb
+-- let initialReq = someRequest \<$ pbDelayed
+-- @
+--
+-- This gives the WebSocket time to connect before the first request is sent.
+-- Without the delay, the request may be silently dropped.
+--
+-- === Avoid Rebuilding Large Subtrees with dyn
+--
+-- 'dyn' and 'dyn_' destroy and rebuild their entire subtree on every change.
+-- For large widgets, this is expensive. Prefer:
+--
+-- * @dynText@ or @display@ for changing text.
+-- * @elDynAttr@ or @elDynClass@ for changing attributes.
+-- * @ffor@ over a 'Dynamic' to compute attributes, not widget trees.
+--
+-- @
+-- -- Expensive: rebuilds the entire div on every change
+-- dyn_ $ ffor stateDyn $ \\s -> elClass "div" (stateToClass s) $ text (stateToText s)
+--
+-- -- Cheaper: only the text and class change, the div stays
+-- elDynClass "div" (stateToClass \<$\> stateDyn) $
+--   dynText (stateToText \<$\> stateDyn)
+-- @
+--
+-- === textInput Is Deprecated
+--
+-- 'textInput' from "Reflex.Dom.Widget.Input" is deprecated. Use
+-- 'inputElement' from "Reflex.Dom.Builder.Class" instead. It is more
+-- flexible and does not require @DomBuilderSpace m ~ GhcjsDomSpace@:
+--
+-- @
+-- -- Deprecated:
+-- ti <- textInput def
+--
+-- -- Preferred:
+-- ie <- inputElement def
+-- @

--- a/reflex-dom-core/src/Reflex/Dom/WebSocket.hs
+++ b/reflex-dom-core/src/Reflex/Dom/WebSocket.hs
@@ -23,6 +23,34 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+-- |
+-- Module: Reflex.Dom.WebSocket
+--
+-- FRP-style WebSocket connections for reflex-dom. Provides a declarative
+-- interface for opening WebSocket connections, sending messages, and receiving
+-- responses as Reflex 'Event' streams.
+--
+-- == Basic usage
+--
+-- @
+-- let wsConfig = def
+--       & webSocketConfig_send .~ (fmap (:[]) sendMessageEvent)
+-- ws <- webSocket \"wss:\/\/example.com\/ws\" wsConfig
+-- let received = _webSocket_recv ws      -- Event t ByteString
+-- let isOpen   = _webSocket_open ws      -- Event t ()
+-- let closed   = _webSocket_close ws     -- Event t (Bool, Text, Text)
+-- @
+--
+-- == Reconnection
+--
+-- By default, the WebSocket will attempt to reconnect on close. Configure
+-- reconnection behavior via 'WebSocketConfig'.
+--
+-- == Rhyolite integration
+--
+-- In the Ace codebase, raw WebSocket usage is typically abstracted by Rhyolite
+-- (which provides typed request\/response and reactive subscriptions on top of
+-- WebSockets). You rarely need to use this module directly.
 module Reflex.Dom.WebSocket
   ( module Reflex.Dom.WebSocket
   , jsonDecode
@@ -58,6 +86,15 @@ import GHCJS.DOM.WebSocket (getReadyState)
 import GHCJS.Marshal
 import qualified Language.Javascript.JSaddle.Monad as JS (catch)
 
+-- | Configuration for a WebSocket connection.
+--
+-- * @_webSocketConfig_send@ — an event carrying lists of messages to send.
+--   Messages are sent in order whenever this event fires.
+-- * @_webSocketConfig_close@ — an event to close the connection, carrying
+--   a close code and reason text.
+-- * @_webSocketConfig_reconnect@ — whether to automatically reconnect on
+--   disconnect (default: 'True').
+-- * @_webSocketConfig_protocols@ — WebSocket sub-protocols to request.
 data WebSocketConfig t a
    = WebSocketConfig { _webSocketConfig_send :: Event t [a]
                      , _webSocketConfig_close :: Event t (Word, Text)
@@ -70,10 +107,18 @@ instance Reflex t => Default (WebSocketConfig t a) where
 
 type WebSocket t = RawWebSocket t ByteString
 
+-- | The result of opening a WebSocket connection. Provides Reflex event streams
+-- for receiving data, connection lifecycle, and errors.
+--
+-- The @a@ parameter is the received message type — 'ByteString' for the
+-- default 'webSocket', or a custom type when using 'webSocket\'' with a
+-- message decoder.
 data RawWebSocket t a
    = RawWebSocket { _webSocket_recv :: Event t a
+                  -- ^ Fires each time a message is received from the server
                   , _webSocket_open :: Event t ()
-                  , _webSocket_error :: Event t () -- eror event does not carry any data and is always
+                  -- ^ Fires once when the connection is established
+                  , _webSocket_error :: Event t () -- error event does not carry any data and is always
                                                    -- followed by termination of the connection
                                                    -- for details see the close event
                   , _webSocket_close :: Event t ( Bool -- wasClean
@@ -82,6 +127,22 @@ data RawWebSocket t a
                                                 )
                   }
 
+-- | Open a WebSocket connection and return event streams for received messages,
+-- open\/close\/error events.
+--
+-- The connection is established after 'postBuild'. Messages are received as
+-- 'ByteString'. Use 'webSocket\'' for custom message decoding.
+--
+-- Requires 'MonadJSM' — cannot be used in static rendering. Wrap in
+-- 'prerender' if needed.
+--
+-- @
+-- rec ws <- webSocket \"ws:\/\/localhost:8080\/ws\" $ def
+--       & webSocketConfig_send .~ (fmap (:[]) sendEvt)
+-- let recvEvt   = _webSocket_recv ws   -- Event t ByteString
+-- let openEvt   = _webSocket_open ws   -- Event t ()
+-- let closeEvt  = _webSocket_close ws  -- Event t (Bool, Word, Text)
+-- @
 webSocket :: (MonadJSM m, MonadJSM (Performable m), PerformEvent t m, TriggerEvent t m, PostBuild t m, IsWebSocketMessage a) => Text -> WebSocketConfig t a -> m (WebSocket t)
 webSocket url config = webSocket' url config onBSMessage
 

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Basic.hs
@@ -9,6 +9,41 @@
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+-- |
+-- Module: Reflex.Dom.Widget.Basic
+--
+-- High-level widget combinators for building DOM. These are the functions you
+-- use in day-to-day reflex-dom code. They are all built on the low-level
+-- 'DomBuilder' methods from "Reflex.Dom.Builder.Class".
+--
+-- == Constraint Guide
+--
+-- Functions here require different constraint sets depending on what they do:
+--
+-- [@DomBuilder t m@] Static element creation: 'el', 'elAttr', 'elClass',
+--   'text', 'blank', 'button', 'divClass'.
+--
+-- [@(DomBuilder t m, PostBuild t m)@] Dynamic content: 'elDynAttr',
+--   'elDynClass', 'dynText', 'display', 'dyn', 'dyn_'.
+--
+-- [@(Adjustable t m, MonadHold t m)@] Stateful widget replacement:
+--   'widgetHold', 'widgetHold_'.
+--
+-- All of these work in both static ('StaticDomBuilderT') and GHCJS contexts.
+-- In static rendering, dynamic content is rendered with its initial value and
+-- never updates. Events (e.g. from 'button') are 'never'.
+--
+-- == Primed Variants
+--
+-- Functions ending in @\'@ (e.g. 'el\'', 'elAttr\'') return an 'Element'
+-- handle alongside the child result. Use 'domEvent' to extract events:
+--
+-- @
+-- (e, _) <- el\' \"button\" $ text \"Click\"
+-- let click = domEvent Click e  -- Event t ()
+-- @
+--
+-- Non-primed variants discard the element handle for convenience.
 module Reflex.Dom.Widget.Basic
   (
   -- * Displaying Values
@@ -108,10 +143,33 @@ partitionMapBySetLT s m0 = Map.fromDistinctAscList $ go (Set.toAscList s) m0
                         then go t geq
                         else (Left h, lt) : go t geq
 
+-- | Create a static text node. This is the most basic way to put text on screen.
+--
+-- @
+-- el \"p\" $ text \"Hello, world!\"
+-- @
+--
+-- Multiple 'text' calls produce adjacent text nodes:
+--
+-- @
+-- el \"p\" $ do
+--   text \"Hello, \"
+--   text \"world!\"
+-- -- renders: \<p\>Hello, world!\<\/p\>
+-- @
 {-# INLINABLE text #-}
 text :: DomBuilder t m => Text -> m ()
 text t = void $ textNode $ def & textNodeConfig_initialContents .~ t
 
+-- | Create a text node whose content changes over time.
+--
+-- Requires 'PostBuild' to sample the initial value of the 'Dynamic'.
+-- In static rendering, only the initial value is used.
+--
+-- @
+-- nameDyn <- holdDyn \"Anonymous\" nameUpdateEvt
+-- dynText nameDyn
+-- @
 {-# INLINABLE dynText #-}
 dynText :: forall t m. (PostBuild t m, DomBuilder t m) => Dynamic t Text -> m ()
 dynText t = do
@@ -135,34 +193,74 @@ dynComment t = do
     ]
   notReadyUntil postBuild
 
+-- | Display a 'Show'-able 'Dynamic' value as text. Equivalent to
+-- @dynText . fmap (T.pack . show)@.
+--
+-- @
+-- counter <- foldDyn (+) (0 :: Int) (1 \<$ clickEvt)
+-- el \"p\" $ do
+--   text \"Count: \"
+--   display counter
+-- @
 display :: (PostBuild t m, DomBuilder t m, Show a) => Dynamic t a -> m ()
 display = dynText . fmap (T.pack . show)
 
+-- | Create a @\<button\>@ element with the given label, returning a click 'Event'.
+--
+-- Internally uses 'domEvent' 'Click' on the created element.
+--
+-- In 'StaticDomSpace', the returned event is 'never'.
+-- In 'GhcjsDomSpace', it fires @()@ on each click.
+--
+-- @
+-- clickEvt <- button \"Submit\"
+-- @
 button :: DomBuilder t m => Text -> m (Event t ())
 button t = do
   (e, _) <- element "button" def $ text t
   return $ domEvent Click e
 
---TODO: Should this be renamed to 'widgetView' for consistency with 'widgetHold'?
--- | Given a Dynamic of widget-creating actions, create a widget that is recreated whenever the Dynamic updates.
---   The returned Event occurs whenever the child widget is updated, which is
---   at post-build in addition to the times at which the input Dynamic is
---   updated, and its value is the result of running the widget.
---   Note:  Often, the type @a@ is an 'Event', in which case the return value is an Event-of-Events that would typically be flattened (via 'switchHold').
+-- | Rebuild a widget entirely whenever the 'Dynamic' changes. Each time the
+-- 'Dynamic' updates, the previous widget is destroyed and a new one is built.
+--
+-- Requires 'Adjustable' (from the @reflex@ package) for dynamic widget
+-- replacement. See also 'widgetHold' for an event-driven variant.
+--
+-- The returned 'Event' fires with the new widget's result each time the widget
+-- is rebuilt (including once at post-build time).
+--
+-- __Warning:__ If @a@ is itself an 'Event', you get an @Event t (Event t b)@.
+-- Flatten with 'switchHold' or 'switchDyn'.
+--
+-- @
+-- dyn $ ffor currentPage $ \\case
+--   HomePage  -> homeWidget
+--   AboutPage -> aboutWidget
+-- @
 dyn :: (Adjustable t m, NotReady t m, PostBuild t m) => Dynamic t (m a) -> m (Event t a)
 dyn = networkView
 
--- | Like 'dyn' but discards result.
+-- | Like 'dyn' but discards the result.
 dyn_ :: (Adjustable t m, NotReady t m, PostBuild t m) => Dynamic t (m a) -> m ()
 dyn_ = void . dyn
 
--- | Given an initial widget and an Event of widget-creating actions, create a widget that is recreated whenever the Event fires.
---   The returned Dynamic of widget results occurs when the Event does.
---   Note:  Often, the type 'a' is an Event, in which case the return value is a Dynamic-of-Events that would typically be flattened (via 'switchDyn').
+-- | Hold a widget, replacing it whenever the 'Event' fires with a new widget
+-- action. Returns a 'Dynamic' that always holds the latest widget's result.
+--
+-- Requires 'Adjustable' (from the @reflex@ package) for dynamic widget
+-- replacement. See also 'dyn' for a 'Dynamic'-driven variant.
+--
+-- Unlike 'dyn', this takes an initial widget and an update 'Event' rather than
+-- a 'Dynamic'. Use when the widget changes in response to discrete events
+-- (e.g. a server response), not continuous state.
+--
+-- @
+-- widgetHold (text \"Loading...\") (buildResult \<$\> responseEvt)
+-- @
 widgetHold :: (Adjustable t m, MonadHold t m) => m a -> Event t (m a) -> m (Dynamic t a)
 widgetHold = networkHold
 
--- | Like 'widgetHold' but discards result.
+-- | Like 'widgetHold' but discards the result.
 widgetHold_ :: (Adjustable t m, MonadHold t m) => m a -> Event t (m a) -> m ()
 widgetHold_ z = void . widgetHold z
 
@@ -190,18 +288,32 @@ elAttr elementTag attrs child = snd <$> elAttr' elementTag attrs child
 elClass :: forall t m a. DomBuilder t m => Text -> Text -> m a -> m a
 elClass elementTag c child = snd <$> elClass' elementTag c child
 
--- | Create a DOM element with Dynamic Attributes
+-- | Create a DOM element with Dynamic Attributes.
 --
--- >>> elClass "div" (constDyn ("class" =: "row")) (return ())
--- <div class="row"></div>
+-- Attribute changes are applied as incremental patches to the real DOM;
+-- attributes that do not change between updates are left untouched.
+--
+-- @
+-- visibleDyn <- toggle True clickEvt
+-- let attrsDyn = ffor visibleDyn $ \\vis ->
+--       if vis then (\"class\" =: \"visible\")
+--              else (\"class\" =: \"hidden\")
+-- elDynAttr \"div\" attrsDyn $ text \"Toggle me\"
+-- @
 {-# INLINABLE elDynAttr #-}
 elDynAttr :: forall t m a. (DomBuilder t m, PostBuild t m) => Text -> Dynamic t (Map Text Text) -> m a -> m a
 elDynAttr elementTag attrs child = snd <$> elDynAttr' elementTag attrs child
 
--- | Create a DOM element with a Dynamic Class
+-- | Create a DOM element with a Dynamic class string.
 --
--- >>> elDynClass "div" (constDyn "row") (return ())
--- <div class="row"></div>
+-- When the 'Dynamic' updates, the @class@ attribute is patched on the real
+-- DOM element. Equivalent to @elDynAttr tag (fmap (\"class\" =:) classDyn)@.
+--
+-- @
+-- isActive <- toggle False clickEvt
+-- let classDyn = ffor isActive $ \\a -> if a then \"tab active\" else \"tab\"
+-- elDynClass \"div\" classDyn $ text \"Tab content\"
+-- @
 {-# INLINABLE elDynClass #-}
 elDynClass :: forall t m a. (DomBuilder t m, PostBuild t m) => Text -> Dynamic t Text -> m a -> m a
 elDynClass elementTag c child = snd <$> elDynClass' elementTag c child
@@ -216,7 +328,12 @@ elDynClass elementTag c child = snd <$> elDynClass' elementTag c child
 el' :: forall t m a. DomBuilder t m => Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 el' elementTag = element elementTag def
 
--- | Create a DOM element with attributes and return the element
+-- | Create a DOM element with attributes and return the element.
+--
+-- @
+-- (imgEl, _) <- elAttr' \"img\" (\"src\" =: \"logo.png\" \<> \"alt\" =: \"Logo\") blank
+-- let mouseEvt = domEvent Mouseover imgEl
+-- @
 {-# INLINABLE elAttr' #-}
 elAttr' :: forall t m a. DomBuilder t m => Text -> Map Text Text -> m a -> m (Element EventResult (DomBuilderSpace m) t, a)
 elAttr' elementTag attrs = element elementTag $ def
@@ -275,22 +392,50 @@ newtype Link t
   = Link { _link_clicked :: Event t ()
          }
 
+-- | Create a clickable @\<a\>@ element with text and a CSS class.
+--
+-- @
+-- lnk <- linkClass \"Sign up\" \"cta-link\"
+-- performEvent_ $ redirect \"\/signup\" \<$ _link_clicked lnk
+-- @
 linkClass :: DomBuilder t m => Text -> Text -> m (Link t)
 linkClass s c = do
   (l,_) <- elAttr' "a" ("class" =: c) $ text s
   return $ Link $ domEvent Click l
 
+-- | Create a clickable @\<a\>@ element with no CSS class. See 'linkClass'.
 link :: DomBuilder t m => Text -> m (Link t)
 link s = linkClass s ""
 
+-- | Shorthand for @elClass \"div\"@. Creates a @\<div\>@ with the given class.
+--
+-- @
+-- divClass \"container\" $ do
+--   divClass \"header\" $ text \"Title\"
+--   divClass \"body\"   $ text \"Content\"
+-- @
 divClass :: forall t m a. DomBuilder t m => Text -> m a -> m a
 divClass = elClass "div"
 
+-- | Render a definition list term\/description pair.
+--
+-- @
+-- el \"dl\" $ do
+--   dtdd \"Name\" $ text \"Alice\"
+--   dtdd \"Age\"  $ text \"30\"
+-- -- renders: \<dt\>Name\<\/dt\>\<dd\>Alice\<\/dd\>\<dt\>Age\<\/dt\>\<dd\>30\<\/dd\>
+-- @
 dtdd :: forall t m a. DomBuilder t m => Text -> m a -> m a
 dtdd h w = do
   el "dt" $ text h
   el "dd" w
 
+-- | Do nothing. Useful as a no-op child widget.
+--
+-- @
+-- elAttr \"img\" (\"src\" =: \"logo.png\") blank   -- self-closing-style element
+-- elAttr \"hr\" mempty blank                    -- no child content needed
+-- @
 blank :: forall m. Monad m => m ()
 blank = return ()
 

--- a/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
+++ b/reflex-dom-core/src/Reflex/Dom/Widget/Input.hs
@@ -14,6 +14,30 @@
 #endif
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+-- |
+-- Module: Reflex.Dom.Widget.Input
+--
+-- High-level input widgets built on top of the raw 'DomBuilder' input elements.
+--
+-- == Deprecation Notice
+--
+-- Most types in this module ('TextInput', 'TextInputConfig', 'textInput') are
+-- __deprecated__ in favor of using 'inputElement' from "Reflex.Dom.Builder.Class"
+-- directly. The raw 'inputElement' is more flexible and avoids an extra
+-- abstraction layer.
+--
+-- == Widgets that are still useful
+--
+-- * 'checkbox' / 'Checkbox' — wraps a checkbox input with a 'Dynamic t Bool'
+-- * 'dropdown' / 'Dropdown' — wraps a @\<select\>@ element with type-safe keys
+-- * 'fileInput' / 'FileInput' — file upload input (requires 'GhcjsDomSpace')
+--
+-- == Constraint notes
+--
+-- * 'textInput', 'fileInput', 'checkboxView' require @DomBuilderSpace m ~ GhcjsDomSpace@
+--   — they cannot run in static rendering
+-- * 'checkbox', 'dropdown' use only @DomBuilder t m@ + @PostBuild t m@ +
+--   @MonadHold t m@ — they work in both static and GHCJS contexts
 module Reflex.Dom.Widget.Input (module Reflex.Dom.Widget.Input, def, (&), (.~)) where
 
 import Prelude

--- a/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
+++ b/reflex-dom/java/org/reflexfrp/reflexdom/MainWidget.java
@@ -31,8 +31,6 @@ import systems.obsidian.HaskellActivity;
 
 public class MainWidget {
   private static Object startMainWidget(final HaskellActivity a, String url, long jsaddleCallbacks, final String initialJS) {
-    CookieManager.setAcceptFileSchemeCookies(true); //TODO: Can we do this just for our own WebView?
-
     // Remove title and notification bars
     a.requestWindowFeature(Window.FEATURE_NO_TITLE);
 
@@ -43,6 +41,11 @@ public class MainWidget {
     ws.setJavaScriptEnabled(true);
     ws.setDomStorageEnabled(true);
     wv.setWebContentsDebuggingEnabled(true);
+    CookieManager cookieManager = CookieManager.getInstance();
+    cookieManager.setAcceptCookie(true);
+    cookieManager.setAcceptThirdPartyCookies(wv, true);
+    cookieManager.setAcceptFileSchemeCookies(true); //TODO: Can we do this just for our own WebView?
+
     // allow video to play without user interaction
     wv.getSettings().setMediaPlaybackRequiresUserGesture(false);
     final AtomicBoolean jsaddleLoaded = new AtomicBoolean(false);
@@ -79,8 +82,7 @@ public class MainWidget {
             catch (IOException e) {
                 Log.i("reflex", "Opening resource failed, Webview will handle the request ..");
                 e.printStackTrace();
-            }
-
+            }	    
             return null;
         }
 

--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -59,7 +59,7 @@ library
   hs-source-dirs: src
   if os(android)
     hs-source-dirs: src-android
-    other-modules: Reflex.Dom.Android.MainWidget
+    exposed-modules: Reflex.Dom.Android.MainWidget
     build-depends:
       aeson >= 1.4 && < 2.2,
       android-activity == 0.2.*,

--- a/reflex-dom/src-android/Reflex/Dom/Android/MainWidget.hsc
+++ b/reflex-dom/src-android/Reflex/Dom/Android/MainWidget.hsc
@@ -1,5 +1,25 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Reflex.Dom.Android.MainWidget
+-- Copyright   :  (c) Ryan Trinkle
+-- License     :  BSD3
+--
+-- Maintainer  :  ryan.trinkle@gmail.com
+--
+-- Android-specific JSaddle bridge via WebView.
+--
+--   'startMainWidget' launches a JSaddle session inside an Android
+--   @WebView@ by calling into the C helper @Reflex_Dom_Android_MainWidget_start@.
+--   JavaScript commands are sent as JSON-encoded batches via
+--   @Reflex_Dom_Android_MainWidget_runJS@; synchronous results come back
+--   through @jsaddle.syncMessage@.
+--
+--   'goBack' and 'withGlobalJSExecutor' expose the back-button integration
+--   used by "Reflex.Dom.Location.Platform" on Android.
+--
+-----------------------------------------------------------------------------
 module Reflex.Dom.Android.MainWidget
   ( startMainWidget
   , goBack

--- a/reflex-dom/src/Reflex/Dom.hs
+++ b/reflex-dom/src/Reflex/Dom.hs
@@ -1,3 +1,23 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Reflex.Dom
+-- Copyright   :  (c) Ryan Trinkle
+-- License     :  BSD3
+--
+-- Maintainer  :  ryan.trinkle@gmail.com
+--
+-- Main public API for @reflex-dom@.
+--
+--   This module re-exports everything from "Reflex.Dom.Core" (the
+--   platform-independent implementation) plus the platform-specific
+--   'run', 'mainWidget', 'mainWidgetWithCss', etc. from
+--   "Reflex.Dom.Internal".  Executables should depend on @reflex-dom@;
+--   libraries should depend on @reflex-dom-core@.
+--
+--   Haddock rendering is disabled due to
+--   <https://github.com/haskell/haddock/issues/979 haddock #979>.
+--
+-----------------------------------------------------------------------------
 -- Disable haddocks on this module due to a bug on haddocks when selectively
 -- reexporting on ghc > 8.2.
 -- https://github.com/haskell/haddock/issues/979

--- a/reflex-dom/src/Reflex/Dom/Internal.hs
+++ b/reflex-dom/src/Reflex/Dom/Internal.hs
@@ -3,6 +3,31 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Reflex.Dom.Internal
+-- Copyright   :  (c) Ryan Trinkle
+-- License     :  BSD3
+--
+-- Maintainer  :  ryan.trinkle@gmail.com
+--
+-- Platform-specific runtime dispatch for @reflex-dom@.
+--
+--   Defines the polymorphic 'run' function that selects the correct
+--   JSaddle backend at compile time via CPP:
+--
+--   * __GHCJS__: @run = id@ (no runtime wrapper needed)
+--   * __jsaddle-warp__: Warp dev server on @JSADDLE_WARP_PORT@ (default 3003)
+--   * __jsaddle-wkwebview__: macOS\/iOS WKWebView (with iOS base-URL handling)
+--   * __Android__: @android-activity@ + @startMainWidget@
+--   * __WASM__: @jsaddle-wasm@ backend
+--   * __Default__: @jsaddle-webkit2gtk@ (Linux desktop)
+--
+--   All @main*@ entry points ('mainWidget', 'mainWidgetWithCss', etc.)
+--   are thin wrappers that compose 'run' with the corresponding
+--   function from "Reflex.Dom.Main".
+--
+-----------------------------------------------------------------------------
 module Reflex.Dom.Internal
   ( module Main
   , run

--- a/reflex-dom/src/Reflex/Dom/Location/Platform.hs
+++ b/reflex-dom/src/Reflex/Dom/Location/Platform.hs
@@ -1,5 +1,18 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+-- |
+-- Module      :  Reflex.Dom.Location.Platform
+-- Copyright   :  (c) Ryan Trinkle
+-- License     :  BSD3
+--
+-- Maintainer  :  ryan.trinkle@gmail.com
+--
+-- Platform-specific browser history navigation.
+--
+--   On Android, 'popHistoryState' uses the JSaddle executor to trigger
+--   the native back button.  On all other platforms it re-exports
+--   'Reflex.Dom.Location.popHistoryState' from @reflex-dom-core@.
+--
 #if defined(ANDROID)
 module Reflex.Dom.Location.Platform where
 


### PR DESCRIPTION
Summary Line: allow third party cookies through .setAcceptThirdPartyCookies

Motivation:

CORS is required for an app entirely run inside of a webview for a connection to the server unless we use websockets. There are many cases such as large files and streaming where it would be undesirable to do through websockets. 

It is also impossible to return the cookie in a request then set it through JS if the Cookie appears to be for a different domain. Currently any android app will have the appassets route as it's origin, since this is where index.html is loaded from, therefore any obelisk backend will be viewed as a different server. Even if that was not the case, there might still be cases where we would like to have an authenticated connection with a true third party