### PR TITLE
Fix wasm build

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,3 +13,9 @@ if os(linux) || os(osx)
 
 package reflex-dom
   flags: +build-examples
+
+-- https://github.com/haskellari/splitmix/pull/73
+source-repository-package
+  type: git
+  location: https://github.com/amesgen/splitmix
+  tag: cea9e31bdd849eb0c17611bb99e33d590e126164

--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,15 @@
 packages:
   reflex-dom-core/
   reflex-dom/
-  chrome-test-utils/
-  reflex-dom-test-selenium/
 
-tests: True
-benchmarks: True
+if os(linux) && arch(x86_64)
+  packages:
+    chrome-test-utils/
+    reflex-dom-test-selenium/
+
+if os(linux) || os(osx)
+   tests: true
+   benchmarks: true
 
 package reflex-dom
   flags: +build-examples

--- a/reflex-dom/examples/sortableList.hs
+++ b/reflex-dom/examples/sortableList.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -16,6 +17,10 @@ import qualified Data.Text as T
 import Data.Time.Clock
 import Reflex.Dom
 import System.Random
+
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
 
 main :: IO ()
 main = mainWidget $ do

--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -50,11 +50,6 @@ flag build-examples
   default: False
   manual: True
 
-flag wasm32
-  description: Build for wasm32 architecture
-  default: False
-  manual: True
-
 library
   hs-source-dirs: src
   if os(android)
@@ -88,7 +83,7 @@ library
           jsaddle >= 0.9.6 && < 0.10,
           jsaddle-wkwebview >= 0.9.6 && < 0.10
       else
-        if flag(wasm32)
+        if arch(wasm32)
           build-depends:
             jsaddle >= 0.9.6 && < 0.10,
             jsaddle-wasm >= 0.1 && < 0.2

--- a/reflex-dom/reflex-dom.cabal
+++ b/reflex-dom/reflex-dom.cabal
@@ -154,6 +154,8 @@ executable sortableList
   if flag(use-reflex-optimizer)
     ghc-options: -fplugin=Reflex.Optimizer
   default-language: Haskell2010
+  if arch(wasm32)
+    ghc-options: -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
 
 executable benchmark
   build-depends: base

--- a/reflex-dom/src/Reflex/Dom/Internal.hs
+++ b/reflex-dom/src/Reflex/Dom/Internal.hs
@@ -93,7 +93,7 @@ triggerBackButton = withGlobalJSExecutor goBack
 import qualified Language.Javascript.JSaddle.Wasm as Wasm (run)
 import Language.Javascript.JSaddle (JSM)
 run :: JSM () -> IO ()
-run = Wasm.run 0
+run = Wasm.run
 
 #else
 import Language.Javascript.JSaddle.WebKitGTK (run)


### PR DESCRIPTION
Using https://github.com/dmjio/miso/pull/778 as reference, this builds and links the `sortableList` executable
`nix shell 'gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org' --command wasm32-wasi-cabal build all`

While a hello world can be executed with `wasmtime` or so, running on the browser is more involved, one needs the steps from https://downloads.haskell.org/ghc/latest/docs/users_guide/wasm.html#the-javascript-api

Couldn't figure out how to get this `wasm32-wasi-cabal install` to cough it up, so I grabbed the `.wasm` from `dist-newstyle/build/wasm32-wasi/ghc-9.12.2.20250327/reflex-dom-0.6.3.3/x/sortableList/build/sortableList/sortableList.wasm` plus a sample index.html and index.js from https://github.com/dmjio/miso/pull/772 and was able to run properly 

![sortableList](https://github.com/user-attachments/assets/6b46b4d8-c8b3-42f6-af5f-221952c83971)
