### PR TITLE
Support hashable 1.5 in js backend

### DIFF
--- a/reflex-dom-core/reflex-dom-core.cabal
+++ b/reflex-dom-core/reflex-dom-core.cabal
@@ -111,7 +111,7 @@ library
     hs-source-dirs: src-ghcjs
     build-depends:
       ghcjs-base,
-      hashable >= 1.2 && < 1.5
+      hashable >= 1.2 && < 1.6
   else
     hs-source-dirs: src-ghc
     if !os(windows)


### PR DESCRIPTION
Fixes #496.

The current vanilla ghc CI doesn't have a hashable constraint so 1.5 was already being picked up as a transitive dep even though the js conditional rules it out.

Turns out `cabal outdated` doesn't see through the platform conditional. Not sure what would work for detecting this - the obvious attempt fails
```
$ cabal outdated --with-compiler=javascript-unknown-ghcjs-ghc --with-hc-pkg=javascript-unknown-ghcjs-ghc-pkg
Error: cabal: unrecognized 'outdated' option
`--with-compiler=javascript-unknown-ghcjs-ghc'

unrecognized 'outdated' option
`--with-hc-pkg=javascript-unknown-ghcjs-ghc-pkg'
 ```
